### PR TITLE
ci: GitHub Actions CI パイプライン導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22, 24]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: npm run test:ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- GitHub Actions CI ワークフローを追加
- Type check → Test → Build の3ステップ
- Node 22 (LTS) + 24 のマトリクスビルド
- `main` への push / PR でトリガー

Closes #3

## Test plan
- [x] ローカルで全ステップ成功確認 (tsc, vitest 179/179, vite build)
- [ ] GitHub Actions での初回実行確認 (PR マージ後)

🤖 Generated with [Claude Code](https://claude.com/claude-code)