### PR TITLE
feat: live attack Phase 1 — e2e 最小一周 (jwt-alg-none)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,32 @@ const res = await apiPost<ResponseType>("/api/endpoint", body, SCOPE);
 <DataFlowPanel scopeId={SCOPE} />
 ```
 
+## DESIGN ⇄ 実装 対応表 (Component Mapping)
+
+DESIGN/30-34 と Phase 1 で生成された実装ファイルの対応関係。
+PR レビュー時の「仕様 ↔ 実装」往復に使う。Phase 2+ で新規ファイルを足すたびに本表を更新する。
+
+| DESIGN セクション | 実装ファイル | 役割 |
+|---|---|---|
+| DESIGN/30 §2-3 (アーキ・データフロー) | `docker-compose.yml`, root `package.json` (workspaces) | コンテナ構成・サービス起動 |
+| DESIGN/30 §7.1 (npm scripts) | root `package.json` の `dev` / `dev:no-docker` / `dev:victim` / `victim:reset` / `victim:logs` | DX (Docker / no-docker フォールバック) |
+| DESIGN/31 §3 (Request スキーマ) | `server/routes/orchestrator-exec.ts` (zod schema) | バリデーション・エラーコード |
+| DESIGN/31 §4 (Response 型) | `shared/api-types.ts` (`OrchestratorExecResponse`, `RawExchange`, `RawHttpRequest/Response`) | 双方向 raw bytes 型 |
+| DESIGN/31 §5 (VICTIM_ALLOWLIST) | `server/routes/orchestrator-exec.ts` (`VICTIM_ALLOWLIST`), `shared/api-types.ts` (`VictimTarget`, `VictimEntry`) | URL 偽造防止 |
+| DESIGN/31 §6 (raw HTTP プロキシ) | `server/routes/orchestrator-exec.ts` (`proxyToVictim`) | Node `http.request` + Host 強制上書き |
+| DESIGN/31 §7 (`_trace` 拡張) | `server/middleware/trace-logger.ts` (`setLiveMode`, `mode`, `victimNote`, `isAttackPath` の orchestrator 追加) | live/narration の区別 |
+| DESIGN/31 §8 (Production guard) | `server/middleware/production-guard.ts` | `NODE_ENV==="production"` で 503 |
+| DESIGN/32 §2 (services/victim-web 構造) | `services/victim-web/{package.json,tsconfig.json,Dockerfile,src/index.ts,src/routes/jwt-vuln.ts}` | 脆弱 victim アプリ |
+| DESIGN/32 §4.1 (JWT 脆弱エンドポイント) | `services/victim-web/src/routes/jwt-vuln.ts` | `POST /jwt/verify` (alg=none 受理) |
+| DESIGN/32 §6 (Dockerfile + compose 安全設定) | `services/victim-web/Dockerfile`, `docker-compose.yml` (victim-web セクション) | tmpfs / cap_drop / read_only |
+| DESIGN/33 §2 (RawHttpComposer) | `src/components/shared/RawHttpComposer.tsx`, `RawHttpComposer.css` | 生 HTTP リクエスト編集 UI |
+| DESIGN/33 §3 (SequenceDiagramView) | **PR-2 で追加予定** | D3 シーケンス図 |
+| DESIGN/33 §4 (AttackPanel 統合) | `src/components/shared/AttackPanel.tsx` (`isLiveMode()`, `onRunLiveScenario`) | 排他 `<Show>` |
+| DESIGN/33 §5 (mode バッジ) | `RawHttpComposer.tsx` の `.raw-http-composer-live-badge` のみ実装。`EducationalWarningBanner` / `AttackScenarioSelector` バッジは **PR-2 で追加予定** | LIVE/NARRATION 表示 |
+| DESIGN/34 §4 (新規安全装置) | `victim-net: internal: true`, `productionGuard`, `Host` 強制上書き, `cap_drop`, `read_only`, `tmpfs` | OS レイヤ防御 |
+| DESIGN/30 §6.2 (`mode` フィールド) | `shared/api-types.ts` (`AttackScenarioMeta.mode`, `liveTemplate`) | live/narration 切替 |
+| DESIGN/30 §5.3 (Phase 2 PoC 第 1 号) | `src/components/auth/attacks/scenarios/jwt-scenarios.ts` (`jwt-alg-none` の `mode: "live"`) + `src/components/auth/JwtInspector.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |
+
 ## ロードマップ: 攻撃デモの live 化 (Phase 1-5, 約 11 週)
 
 | Phase | 内容 | 期間 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,59 +31,105 @@ OSI参照モデルのインタラクティブ学習ツール。認証・認可�
 - D3 が管理する SVG 内部に Solid は介入しない
 
 ## ディレクトリ構造
+
+### 現状 (becc5fc 時点)
+
 ```
-server/                           # Hono バックエンド (port 3001)
-├── index.ts                      # エントリポイント、全ルート登録
-├── db/schema.ts                  # SQLite スキーマ (12テーブル) + seed
-├── middleware/trace-logger.ts    # _trace ミドルウェア (DB/暗号/セッション操作を記録)
-└── routes/
-    ├── password-auth.ts          # 登録/ログイン (bcrypt)
-    ├── jwt-ops.ts                # JWT 署名/検証/デコード (HS256/RS256)
-    ├── session-auth.ts           # セッション認証 (Cookie + DB)
-    ├── token-auth.ts             # トークン認証 (JWT Bearer)
-    ├── oauth-sim.ts              # OAuth 2.0 認可サーバーシミュレーション
-    ├── rbac.ts                   # RBAC/ABAC/ACL アクセス制御評価
-    ├── webauthn.ts               # FIDO2 登録/認証 (@simplewebauthn/server)
-    ├── kerberos-sim.ts           # Kerberos KDC シミュレーション (AES暗号化チケット)
-    ├── oidc-saml-sim.ts          # OIDC (PKCE) + SAML IdP シミュレーション
-    ├── sso-apikey.ts             # SSO セッション伝播 + API キー生成/HMAC
-    └── tls-sim.ts                # TLS 1.3 ハンドシェイク (ECDHE鍵交換)
-shared/
-└── api-types.ts                  # サーバー/クライアント共有型 (ServerTrace等)
-src/
-├── api/client.ts                 # fetch ラッパー (リクエスト/レスポンス自動キャプチャ)
-├── i18n/context.tsx              # 言語切替 Signal + Provider
-├── types/{index,security}.ts     # 型定義
-├── data/*.ts                     # 静的データ (layers, protocols, scenarios, auth, security)
-├── state/{app,security}-state.ts # グローバル Signal
-├── utils/{colors,animation,security-colors}.ts
-└── components/
-    ├── shared/
-    │   ├── DataFlowPanel.tsx      # HTTP/Trace/DB タブ付き折りたたみパネル
-    │   └── (TabBar, StepControl, etc.)
-    ├── overview/       # View 1: 7層ダイアグラム
-    ├── encapsulation/  # View 2: ヘッダ追加/除去アニメーション
-    ├── scenario/       # View 3: HTTP/DNS/TLS パケットフロー
-    ├── comparison/     # View 4: OSI⇔TCP/IP マッピング
-    ├── auth/           # View 5: 全10方式にインタラクティブデモ追加済み
-    └── security/       # View 6: パケットモニター/証明書/FW/攻撃マップ
+osi-reference/
+├── server/                          # Hono バックエンド (port 3001) — Phase 1 で orchestrator 役に進化
+│   ├── index.ts                     # エントリポイント、全ルート登録
+│   ├── db/schema.ts                 # SQLite スキーマ + seed
+│   ├── middleware/trace-logger.ts   # _trace ミドルウェア (DB/暗号/セッション操作を記録)
+│   └── routes/
+│       ├── password-auth.ts         # 登録/ログイン (bcrypt) + 攻撃ルート /attack/*
+│       ├── jwt-ops.ts               # JWT 署名/検証 + 攻撃ルート /attack/* (Phase 1 で live 版を orchestrator/exec 経由に)
+│       ├── session-auth.ts          # セッション認証 (Cookie + DB) + /attack/*
+│       ├── token-auth.ts            # トークン認証 (JWT Bearer) + /attack/*
+│       ├── oauth-sim.ts             # OAuth 2.0 + /attack/*
+│       ├── rbac.ts                  # RBAC/ABAC/ACL + /attack/*
+│       ├── webauthn.ts              # FIDO2 + /attack/*
+│       ├── kerberos-sim.ts          # Kerberos KDC + /attack/*
+│       ├── oidc-saml-sim.ts         # OIDC (PKCE) + SAML IdP + /attack/*
+│       ├── sso-apikey.ts            # SSO + API キー + /attack/*
+│       ├── mfa-totp.ts              # MFA/TOTP + /attack/*
+│       ├── passkey.ts               # パスキー + /attack/*
+│       └── tls-sim.ts               # TLS 1.3 ハンドシェイク + /attack/*
+├── shared/
+│   └── api-types.ts                 # 共有型 (ServerTrace, AttackScenarioMeta, AttackResult<TExtra>, AttackStep 等)
+├── src/
+│   ├── api/client.ts                # fetch ラッパー (リクエスト/レスポンス自動キャプチャ)
+│   ├── i18n/context.tsx             # 言語切替 Signal + Provider
+│   ├── types/{index,security}.ts    # 型定義
+│   ├── data/*.ts                    # 静的データ
+│   ├── state/{app,security,attack}-state.ts # グローバル Signal
+│   ├── utils/{colors,animation,security-colors}.ts
+│   └── components/
+│       ├── shared/
+│       │   ├── DataFlowPanel.tsx    # HTTP/Trace/DB 折りたたみパネル
+│       │   ├── AttackPanel.tsx      # 攻撃デモ統合 (現状ナレーション型、Phase 1 で live モード追加)
+│       │   ├── AttackStepTimeline.tsx, AttackResultBanner.tsx, AttackDefensePanel.tsx
+│       │   ├── AttackScenarioSelector.tsx, EducationalWarningBanner.tsx
+│       │   └── (TabBar, StepControl, etc.)
+│       ├── overview/                # View 1: 7層ダイアグラム
+│       ├── encapsulation/           # View 2: ヘッダ追加/除去アニメーション
+│       ├── scenario/                # View 3: HTTP/DNS/TLS パケットフロー
+│       ├── comparison/              # View 4: OSI⇔TCP/IP マッピング
+│       ├── auth/                    # View 5: 12 タブ × 38 攻撃シナリオ
+│       │   └── attacks/scenarios/*.ts # タブ別攻撃メタデータ (12 ファイル)
+│       └── security/                # View 6: パケットモニター/証明書/FW/攻撃マップ
+└── DESIGN/                          # 攻撃カタログ設計書 (00-04 共通 + 10-21 タブ別)
 ```
+
+### Phase 1 で追加予定 (live attack 化 — `live_attack_architecture` メモリ参照)
+
+```
+osi-reference/
+├── services/                        # 新規: 独立コンテナサービス群 (npm workspaces)
+│   ├── victim-web/                  # 脆弱 Hono アプリ (orchestrator から実 HTTP で叩く対象)
+│   │   ├── package.json             # 独立 package
+│   │   ├── Dockerfile
+│   │   ├── src/
+│   │   └── tsconfig.json
+│   ├── attacker-shell/              # alpine + curl/openssl/nc (--read-only --cap-drop=ALL)
+│   │   └── Dockerfile
+│   └── README.md                    # サービス追加手順テンプレ
+├── docker-compose.yml               # victim-net (internal=true) で外部 egress 遮断
+└── package.json                     # workspaces: ["services/*"] 化
+```
+
+`server/` は **orchestrator** 役に追加進化 (`POST /api/orchestrator/exec` で raw HTTP プロキシ + `_trace` 整形)。既存ナレーション型 `/attack/*` は Phase 5 まで残置 → C/D 群シナリオで継続使用。
+
+### 将来計画 (L1/L2 深掘り — NAND → ブレッドボード → NBIT CPU)
+
+```
+osi-reference/
+├── src/components/circuits/         # 将来: Blender Node 風 + ブレッドボード UI
+├── packages/                        # 将来: 共有ライブラリ
+│   └── nand-sim-core/               # 必要になったら WASM ベース sim core 等
+└── services/                        # ハーネス系外部連携サービスもここに追加
+```
+
+実装は未着手。`services/` 構造は L1/L2 教材の追加にも適合 (1 PJ N サービス)。
 
 ## 認証・認可インタラクティブデモ (実装済み)
-全10タブに実動作デモを追加完了。各デモは `DataFlowPanel` で HTTP リクエスト/レスポンスと `_trace` (DB操作・暗号処理・セッション操作) をリアルタイム表示。
+全12タブに正常系デモ + 攻撃シナリオ (計 38 シナリオ、PR #6 = becc5fc) を実装。各デモは `DataFlowPanel` で HTTP リクエスト/レスポンスと `_trace` (DB操作・暗号処理・セッション操作) をリアルタイム表示。
 
-| タブ | デモ内容 | バックエンドルート |
-|------|---------|-------------------|
-| 認証方式 | パスワード登録/ログイン、bcryptハッシュ可視化、usersテーブル表示 | password-auth.ts |
-| JWT | サーバーサイド署名 (HS256/RS256)、検証、改竄検出、有効期限カウントダウン | jwt-ops.ts |
-| OAuth 2.0 | ライブフロー (認可コード → トークン交換 → リソースアクセス) | oauth-sim.ts |
-| Session vs Token | 左右並列デモ (Cookie認証 vs Bearer トークン) | session-auth.ts, token-auth.ts |
-| アクセス制御 | RBAC/ABAC/ACL アクセスチェック、評価ステップ可視化 | rbac.ts |
-| FIDO2/WebAuthn | 実WebAuthn API呼び出し、チャレンジ/レスポンス可視化 | webauthn.ts |
-| OIDC & SAML | OIDC PKCE付きフロー + ID Token、SAML アサーション生成 | oidc-saml-sim.ts |
-| Kerberos | KDCシミュレーション、AES暗号化チケット生成/復号 | kerberos-sim.ts |
-| TLS詳細 | ハンドシェイクシミュレーション (ECDHE、証明書、セッションキー) | tls-sim.ts |
-| SSO/API Key | SSO セッション伝播、API キー生成・HMAC検証 | sso-apikey.ts |
+| タブ | 正常系デモ | 攻撃シナリオ | バックエンドルート |
+|------|---------|------|-------------------|
+| 認証方式 | パスワード登録/ログイン、bcryptハッシュ可視化 | bcrypt vs rainbow / timing / bruteforce | password-auth.ts |
+| JWT | サーバー署名 (HS256/RS256)、検証、改竄検出 | alg=none / 弱秘密鍵 / 署名ストリッピング / kid injection | jwt-ops.ts |
+| OAuth 2.0 | ライブフロー (認可コード → トークン交換) | state CSRF / redirect_uri バイパス / コード傍受 | oauth-sim.ts |
+| Session vs Token | 左右並列 (Cookie 認証 vs Bearer) | セッション固定 / XSS Cookie 窃取 / リプレイ | session-auth.ts, token-auth.ts |
+| アクセス制御 | RBAC/ABAC/ACL 評価ステップ可視化 | IDOR / 水平・垂直権限昇格 / ABAC 改竄 | rbac.ts |
+| FIDO2/WebAuthn | 実 `navigator.credentials.*` 呼び出し | フィッシング耐性 / vs パスワード / チャレンジリプレイ | webauthn.ts |
+| OIDC & SAML | OIDC PKCE + ID Token、SAML アサーション | SAML XSW / アサーションリプレイ / aud 検証省略 | oidc-saml-sim.ts |
+| Kerberos | KDC シミュ、AES 暗号化チケット | Pass-the-Ticket / Kerberoasting / Golden Ticket | kerberos-sim.ts |
+| TLS詳細 | ハンドシェイク (ECDHE、証明書) | ダウングレード / 自己署名 MITM / 弱 cipher | tls-sim.ts |
+| SSO/API Key | SSO セッション伝播、HMAC 検証 | API キー漏洩 / HMAC バイパス / リプレイ | sso-apikey.ts |
+| MFA/TOTP | TOTP コード生成/検証 | OTP リプレイ / 時刻ずれ DoS / SIM スワップ | mfa-totp.ts |
+| パスキー | プラットフォーム/クロスデバイス | フィッシング耐性 / クラウド同期侵害 / cross-device MITM | passkey.ts |
+
+攻撃シナリオは現状「サーバ側ナレーション生成型」。Phase 1 以降で順次 live 化 (実 HTTP + Docker 隔離 victim) — 詳細は本ファイル「ロードマップ」section 参照。
 
 ## バックエンド設計パターン
 - **_trace レスポンス**: 全API レスポンスに `_trace` フィールドで教育用メタデータ (DbQuery[], CryptoOp[], SessionOp[]) を自動付与
@@ -103,17 +149,30 @@ const res = await apiPost<ResponseType>("/api/endpoint", body, SCOPE);
 <DataFlowPanel scopeId={SCOPE} />
 ```
 
-## 実装計画
-詳細な Phase 別実装手順は `PLAN.md` を参照。
+## ロードマップ: 攻撃デモの live 化 (Phase 1-5, 約 11 週)
+
+| Phase | 内容 | 期間 |
+|---|---|---|
+| 1 | docker-compose + `services/victim-web/` + orchestrator/exec + RawHttpComposer 共通基盤 | 1-2 週 |
+| 2 | PoC 5 件 (jwt-alg-none, oauth-state-csrf, rbac-idor, session-fixation, mfa-otp-replay) | 2 週 |
+| 3 | A 群残り 13 件 | 4 週 |
+| 4 | B 群 5 件 (TLS / SAML XSW) → victim-tls-proxy / victim-saml-idp 追加 | 3 週 |
+| 5 | C/D 群バッジ整理、`is_attack_sim` 削除検討 | 1 週 |
+
+詳細 (38 シナリオ分類、安全制約への影響、意思決定履歴) は `CHECKPOINT.md` および `live_attack_architecture` メモリを参照。Phase 1-2 は `dev:no-docker` フォールバック維持、Phase 3+ から Docker 必須。
+
+正式仕様化は Step A (`design-phase` スキル) で `DESIGN/30-live-attack-architecture.md` 以降に書き起こす予定。
 
 ## セッション引き継ぎ手順
-1. `cd osi-reference && npm run dev` で現状確認 (フロント+バックエンド同時起動)
-2. `curl http://localhost:3001/api/health` でバックエンド動作確認
-3. 認証タブ (`/auth/*`) で各デモの動作確認
-4. 改善が必要な場合は該当する `server/routes/*.ts` と `src/components/auth/*.tsx` を修正
+1. `git status` / `git log --oneline -5` で進捗確認
+2. `CHECKPOINT.md` および `live_attack_architecture` / `phase35_backlog` メモリを確認
+3. `npm run dev` で現状動作確認 (フロント:3000, バックエンド:3001)
+4. `curl http://localhost:3001/api/health` でバックエンド疎通確認
+5. 認証タブ (`/auth/*`) で各デモ動作確認、必要に応じて `server/routes/*.ts` と `src/components/auth/*.tsx` を修正
 
-## 今後の改善候補
-- i18n: デモ部分の日英テキスト充実
-- PCBテーマ: デモUI部分のテーマ統一性向上
-- エラーハンドリング: サーバー接続失敗時のグレースフルフォールバック
-- テスト: バックエンドAPI のVitestテスト追加
+## 並行残課題 (live 化計画と独立)
+`phase35_backlog` メモリ参照:
+- GitGuardian 永続化 (`.gitguardian.yaml` で test/demo 系 secret 7 件 ignore) — CI ノイズ削減効果大
+- SEC-13 (`setInterval` クリーンアップ + `attack_log` TTL)、SEC-6、SEC-FIDO2-1 等 Tier 3
+- D07/D09/D10/D13/D14/D15/D16: AttackStep payload 文言調整
+- ROB-FIND-005/012: `AttackResult.extra` optional / outcome リテラル型分割

--- a/DESIGN/30-live-attack-architecture.md
+++ b/DESIGN/30-live-attack-architecture.md
@@ -1,0 +1,591 @@
+---
+title: 攻撃デモカタログ — live 化アーキテクチャ
+phase: design
+audience: 開発者・教材執筆者
+last-updated: 2026-05-02
+safety-reviewed: false
+---
+
+# 30. 攻撃デモカタログ — live 化アーキテクチャ
+
+## 1. 目的と背景
+
+### 1.1 現状ナレーション型の課題
+
+PR #6 (becc5fc) でリリースした攻撃デモカタログ (38 シナリオ) は、認証タブ内に Attacker View を追加し、
+各攻撃の手順を `AttackStep[]` のタイムラインとして可視化する形式で実装した。
+ユーザー評価では次の課題が指摘されている。
+
+> 「文字列ベースでイメージが付きづらい。MD まとめで十分なレベル」
+
+具体的な問題点は以下の通り。
+
+| 問題 | 現状の挙動 | 学習者への影響 |
+|------|-----------|--------------|
+| リクエスト生成がサーバー側 | `POST /api/jwt/attack/alg-none` をサーバーが JWT を偽造して結果を返す | 「攻撃者がどのリクエストを組み立てるか」を体感できない |
+| HTTP の生のやり取りが不可視 | DataFlowPanel に表示されるのはサーバー内部の _trace のみ | ヘッダ・ボディを見て脆弱性を発見する体験が欠ける |
+| victim が orchestrator と同居 | 脆弱な実装と安全な実装が同一プロセスに混在 | 「このサーバーが脆弱なのか安全なのか」が曖昧 |
+| 隔離がソフトウェア境界のみ | `localhost` への fetch を API 規約で制限しているだけ | OS レイヤでの egress 遮断がなく、概念実証として不完全 |
+
+### 1.2 live 化の目的
+
+学習者がブラウザから生 HTTP リクエストを自ら組み立て、Docker で隔離された脆弱 victim コンテナと
+**実通信**して攻撃の成立を観察できる体験を提供する。これにより次の教育効果を実現する。
+
+1. **リクエスト構築の体感**: `RawHttpComposer` コンポーネントでヘッダ・ボディを直接編集し、
+   JWT ヘッダの `alg` を `none` に書き換える操作が学習者自身の手で起こる
+2. **実 HTTP の可視化**: orchestrator がキャプチャした raw bytes とレイテンシを DataFlowPanel に表示し、
+   パケットレベルで攻撃リクエストを確認できる
+3. **victim の独立性**: 脆弱な実装を持つ `victim-web` コンテナが orchestrator と分離されており、
+   「この victim は脆弱な設定のサーバーです」という文脈が明確になる
+4. **OS レイヤ隔離の実証**: `victim-net: internal: true` により victim が外部通信不能であることを
+   学習者に説明でき、安全制約の技術的根拠が実物で示せる
+
+### 1.3 既存攻撃カタログ (PR #6) との関係
+
+既存のナレーション型攻撃デモ (`server/routes/attack-*.ts` と `src/components/auth/attacks/`) は
+**Phase 5 まで残置**する。C/D 区分のシナリオ 15 件は最終的にもナレーション型を維持し確定する。
+A/B 区分の live 化が完了した時点でナレーション版に「live 版に移行済み」バッジを付与し、
+Phase 5 で UI 整理を行う。
+
+---
+
+## 2. 全体アーキテクチャ — 案 C ハイブリッド採用
+
+### 2.1 案の比較
+
+| 観点 | 案 A (単一 victim 同居) | 案 B (protocol 別分割) | 案 C (ハイブリッド) |
+|------|------------------------|----------------------|-------------------|
+| victim コンテナ数 | 1 (orchestrator と同じ Hono プロセス) | 4+ (jwt-victim, oauth-victim, tls-proxy ...) | Phase 1-2: 1、Phase 4: 3 |
+| 実装コスト (Phase 1) | 低 (コンテナ追加なし) | 高 (複数 victim 同時実装) | 低から中へ段階的 |
+| 隔離の明確さ | 低 (同一プロセス内のシム) | 高 (protocol 専用コンテナ) | 中 → 高 (段階的強化) |
+| DX (docker-compose) | なし | compose が複雑 | 段階的に compose が成長 |
+| TLS/SAML 等の実化可否 | 不可 (共有 TLS 設定に干渉) | 可 | Phase 4 から可 |
+| `dev:no-docker` フォールバック | 常時可 | 不可 | Phase 1-2 のみ維持 |
+
+**採用理由**: Phase 1-2 は victim-web 単一コンテナで開始し、学習者・開発者双方の摩擦を最小化する。
+TLS ダウングレードや SAML XSW など protocol 専用インフラが必要な B 群は Phase 4 で追加し、
+案 B の恩恵を部分的に取り込む進化型アーキテクチャとする。
+
+### 2.2 コンテナ構成図
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ブラウザ (SolidJS, port 3000)                                   │
+│    RawHttpComposer ─── DataFlowPanel ─── AttackResultBanner     │
+└──────────────────────────────┬──────────────────────────────────┘
+                               │ /api/orchestrator/exec
+                               │ (Vite proxy → localhost:3001)
+┌──────────────────────────────▼──────────────────────────────────┐
+│  orchestrator (Hono, port 3001)                                  │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │  既存ルート: /api/jwt, /api/oauth, /api/rbac, ...        │   │
+│  │  既存ナレーション攻撃: /api/jwt/attack/alg-none, ...     │   │
+│  │  ─────────────────────────────────────────────────────   │   │
+│  │  新規: POST /api/orchestrator/exec                        │   │
+│  │    VICTIM_ALLOWLIST 検証                                  │   │
+│  │    http.request → victim-net 内部へ転送                   │   │
+│  │    raw bytes キャプチャ + elapsed ms 計測                 │   │
+│  │    AttackResult + _trace (isAttackMode: true, mode: "live") │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│  SQLite: server/db/data.sqlite (orchestrator 固有)               │
+└──────────┬────────────────────────────────────────────────────┘
+           │ victim-net (internal: true — OS レイヤ egress 遮断)
+           ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  victim-net (Docker bridge network, internal: true)              │
+│                                                                  │
+│  ┌───────────────────────────┐  ┌────────────────────────────┐  │
+│  │ victim-web (Hono, :4001)  │  │ attacker-shell             │  │
+│  │  脆弱エンドポイント群      │  │ (Alpine, read-only)        │  │
+│  │  /login — rate limit なし │  │ 辞書ブルートフォース用     │  │
+│  │  /jwt/verify-kid          │  │ --cap-drop=ALL             │  │
+│  │  /oauth/authorize         │  │ --pids-limit=64            │  │
+│  │  /session/login           │  │                            │  │
+│  │  /rbac/resource/:id       │  └────────────────────────────┘  │
+│  │  SQLite: victim-data.sqlite│                                  │
+│  │  (tmpfs — 再起動でクリア) │                                  │
+│  └───────────────────────────┘                                  │
+│                                                                  │
+│  ─── Phase 4 追加 ─────────────────────────────────────────     │
+│  ┌───────────────────────────┐  ┌────────────────────────────┐  │
+│  │ victim-tls-proxy          │  │ victim-saml-idp            │  │
+│  │ (nginx, 旧 TLS 設定)      │  │ (SimpleSAMLphp または Hono │  │
+│  │ TLSv1.0 強制対応           │  │  SAML 実装)                │  │
+│  └───────────────────────────┘  └────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### 2.3 ネットワーク方針
+
+`docker-compose.yml` のネットワーク定義:
+
+```yaml
+networks:
+  victim-net:
+    driver: bridge
+    internal: true   # victim-net からのインターネット egress を OS レイヤで遮断
+```
+
+orchestrator のみ `victim-net` と `host` ブリッジの二刀流構成とする。
+
+```yaml
+services:
+  orchestrator:
+    networks:
+      - default        # ホスト (port 3001) 向け
+      - victim-net     # victim-web への転送用
+  victim-web:
+    networks:
+      - victim-net     # orchestrator からのみ到達可
+```
+
+### 2.4 DB 分離
+
+| コンテナ | SQLite ファイル | 用途 |
+|---------|----------------|------|
+| orchestrator | `server/db/data.sqlite` (gitignored) | 既存 12 テーブル + attack_log |
+| victim-web | `victim-data.sqlite` (tmpfs マウント — 再起動でリセット、CLAUDE.md「データはエフェメラル」方針と整合) | 脆弱シードユーザー・セッション・OTP |
+
+`POST /api/reset` は orchestrator の DB のみリセットする。
+victim-web の DB は tmpfs マウントのため `docker compose restart victim-web` で自動クリアされる。
+専用の `POST /api/orchestrator/victim-reset` エンドポイントからも再起動をトリガーできる。
+
+---
+
+## 3. データフロー — alg=none を例に
+
+### 3.1 end-to-end シーケンス
+
+PoC 第 1 号 `jwt-alg-none` を例にフローを示す。
+
+```
+ブラウザ
+  │
+  │  1. 学習者が RawHttpComposer で JWT header と Body を編集
+  │     header: { "alg": "none", "typ": "JWT" }
+  │     payload: { "sub": "seed_alice", "role": "admin" }
+  │     signature: ""   ← 署名を空文字列に
+  │     → Body タブで {"token": "<偽造 JWT>"} を入力
+  │
+  │  POST /api/orchestrator/exec
+  │  {
+  │    "target": "victim-web",
+  │    "method": "POST",
+  │    "path": "/jwt/verify",
+  │    "headers": { "Content-Type": "application/json" },
+  │    "body": "{\"token\": \"eyJhbGciOiJub25lIn0....\"}"
+  │  }
+  ▼
+orchestrator (port 3001)
+  │
+  │  2. VICTIM_ALLOWLIST 検証
+  │     allowlist = Map { "victim-web" → "http://victim-web:4001" }
+  │     target "victim-web" → 許可
+  │
+  │  3. http.request("http://victim-web:4001/jwt/verify", ...)
+  │     victim-net 内部通信 (egress なし)
+  │
+  │  4. raw bytes キャプチャ (双方向)
+  │     browserToOrchestrator.request.line: "POST /api/orchestrator/exec HTTP/1.1"
+  │     orchestratorToVictim.request.line:  "POST /jwt/verify HTTP/1.1"
+  │     orchestratorToVictim.response.line: "HTTP/1.1 200 OK"
+  │     browserToOrchestrator.response.line: "HTTP/1.1 200 OK"
+  │     elapsedMs: 12
+  │
+  │  5. AttackResult 構築
+  │     {
+  │       scenarioId: "jwt-alg-none",
+  │       outcome: "succeeded",   ← victim が 200 を返した
+  │       mode: "live",
+  │       rawRequest, rawResponse, elapsedMs,
+  │       ...
+  │     }
+  │
+  │  6. _trace 付与
+  │     { isAttackMode: true, mode: "live", attackSteps: [...] }
+  │
+  ▼
+ブラウザ
+  │
+  │  7. DataFlowPanel 更新
+  │     HTTP タブ: rawRequest / rawResponse を整形表示 (ヘッダ強調)
+  │     Trace タブ: AttackStep タイムライン + 経過時間
+  │     Sequence タブ: ブラウザ → orchestrator → victim の 3 段フロー図
+  │
+  ▼
+  AttackResultBanner
+    「この実装は alg 検証が省略されているため署名バイパスが成立しました」
+    ↓ AttackDefensePanel 自動展開
+    「防御: jwt.verify() の algorithms オプションに ["HS256"] を明示的に指定する」
+```
+
+### 3.2 ナレーション型との対比
+
+| ステップ | ナレーション型 (現在) | live 型 (新規) |
+|---------|---------------------|---------------|
+| JWT 偽造 | orchestrator が `buildAlgNoneToken()` で生成 | 学習者が RawHttpComposer で直接編集 |
+| victim への送信 | orchestrator 内の `verifyWithoutAlgCheck()` を呼ぶ | HTTP リクエストが victim-web コンテナに到達 (`POST /jwt/verify` body 内 token) |
+| 脆弱性の場所 | サーバー内の分岐フラグ | victim-web の `/jwt/verify` 実装コード自体 (alg=none を受理) |
+| raw bytes | 存在しない | browser⇄orchestrator / orchestrator⇄victim の双方向 raw bytes を DataFlowPanel に表示 |
+| 隔離根拠 | API 規約 (ソフトウェア) | Docker network `internal: true` (OS レイヤ) |
+
+---
+
+## 4. 38 シナリオ分類 (A/B/C/D 区分)
+
+### 4.1 区分定義
+
+| 区分 | 定義 | 対応方針 |
+|------|------|---------|
+| **A** | 実化インパクト高。victim-web の HTTP エンドポイントと RawHttpComposer で体感可能 | Phase 2-3 で live 化する |
+| **B** | 技術的に重い実化価値あり。専用コンテナ (victim-tls-proxy 等) が必要 | Phase 4 で live 化する |
+| **C** | ナレーション型を維持確定。実 NW 条件依存・概念のみ・教材外の重い処理 | Phase 5 でバッジ整理 |
+| **D** | 失敗デモ (攻撃が設計上成立しないことを示す)。一部 A 化できる部分を「部分 A」と注記 | ナレーション維持 + 部分 A を別途追加 |
+
+### 4.2 全シナリオ分類表
+
+| # | tabId | scenario-id | 区分 | 補足 |
+|---|---|---|---|---|
+| 1 | auth-methods | password-rainbow-vs-bcrypt | C | レインボーテーブル生成は重い + 教材外 |
+| 2 | auth-methods | password-timing-string-compare | C | 実 NW では再現困難。概念のみ |
+| 3 | auth-methods | password-bruteforce-no-rate-limit | A | victim-web `/login` で実 HTTP ループ (上限 20 回) |
+| 4 | jwt | jwt-alg-none | A | **PoC 第 1 号**。RawHttpComposer 必須 |
+| 5 | jwt | jwt-weak-secret-bruteforce | A | attacker-shell で辞書 200 件上限 |
+| 6 | jwt | jwt-signature-stripping | A | alg=none と同基盤。RawHttpComposer 流用 |
+| 7 | jwt | jwt-kid-injection | A | victim-web `/jwt/verify-kid` (path traversal 脆弱版) |
+| 8 | oauth | oauth-state-csrf | A | Phase 2 PoC 第二候補 |
+| 9 | oauth | oauth-redirect-uri-bypass | A | victim-web `/oauth/authorize` 部分一致検証 |
+| 10 | oauth | oauth-code-via-referer | C | Referer 漏洩は実環境依存。ブラウザ制御不可 |
+| 11 | session-vs-token | session-fixation | A | sid 強制 → ログイン → 再生成なし確認 |
+| 12 | session-vs-token | session-xss-cookie-theft | A | victim-web に HttpOnly 無し Cookie 発行エンドポイント |
+| 13 | session-vs-token | token-replay | A | jti 検証なしリフレッシュ口を victim-web に用意 |
+| 14 | rbac | rbac-idor | A | Phase 2 PoC 第三候補 |
+| 15 | rbac | rbac-horizontal-privilege-escalation | A | IDOR と同経路。user-id 差し替えのみ |
+| 16 | rbac | rbac-vertical-privilege-escalation | A | role=user JWT 改竄 (alg=none と組合せ可) |
+| 17 | rbac | rbac-abac-attribute-tampering | A | X-User-Dept ヘッダで属性偽装 |
+| 18 | fido2 | fido2-phishing-origin-rejection | D | `fake.localhost:8081` を攻撃者 origin に設定。失敗デモ |
+| 19 | fido2 | fido2-vs-password-phishing | D + 部分A | パスワード側のみ実フィッシング (3 と同基盤で部分 A 化) |
+| 20 | fido2 | fido2-challenge-replay | D | Defender 強化で十分。失敗デモ |
+| 21 | oidc-saml | saml-xsw | B | victim-saml-idp (Phase 4) が必要 |
+| 22 | oidc-saml | saml-assertion-replay | A | 同一 assertion を 2 回 POST して victim が受け入れるか確認 |
+| 23 | oidc-saml | oidc-id-token-spoofing | A | aud/iss 検証なし victim-web エンドポイント |
+| 24 | kerberos | kerberos-pass-the-ticket | B (限定) | victim-web 内で完結する KDC なし簡略版で部分 B 化 |
+| 25 | kerberos | kerberos-kerberoasting | C | 完全実化は KDC + impacket 必要。概念のみ |
+| 26 | kerberos | kerberos-golden-ticket | C | krbtgt 偽造は概念のみ。実化不可 |
+| 27 | tls-deep | tls-version-downgrade | B | victim-tls-proxy (Phase 4) が必要 |
+| 28 | tls-deep | tls-self-signed-mitm | B | mitmproxy in attacker-shell (Phase 4) |
+| 29 | tls-deep | tls-weak-cipher-negotiation | B | 27 と同基盤 |
+| 30 | sso-idp-apikey | apikey-leakage | A | URL クエリで access_log 漏洩。victim-web `/resource?key=` |
+| 31 | sso-idp-apikey | apikey-hmac-bypass | A | victim-web HMAC 検証省略版エンドポイント |
+| 32 | sso-idp-apikey | apikey-replay-no-timestamp | A | 13 と同基盤。replay_nonce テーブルなし版 |
+| 33 | mfa | mfa-otp-replay | A | **Phase 2 PoC 第五候補**。nonce/used フラグなし victim エンドポイント |
+| 34 | mfa | mfa-time-window-too-wide | C | ネットワーク条件依存。概念説明で十分 |
+| 35 | mfa | mfa-sms-swap | C | キャリアへの社会工学。技術実化不可 |
+| 36 | passkey | passkey-phishing-resistance | D + 部分A | 18 同様 fake.localhost 化。失敗デモ |
+| 37 | passkey | passkey-cloud-sync-compromise | C | クラウド側侵害は概念。実化不可 |
+| 38 | passkey | passkey-cross-device-mitm | C | BLE/QR MITM 実化不可 |
+
+**集計**: A=18、B=5、C=11、D=4 (D のうち 3 件は部分 A 化あり)。
+A 群 18 件 + D 部分 A 3 件 = 実化対象約 21 件 (全体の約 55%)。
+
+---
+
+## 5. Phase 1-5 ロードマップ
+
+### 5.1 Phase 一覧
+
+| Phase | 内容 | 主な Deliverable | 想定期間 | 想定 PR 数 |
+|-------|------|----------------|---------|-----------|
+| 1 | インフラ整備 | docker-compose + victim-web スケルトン + orchestrator/exec + RawHttpComposer 基盤 + `dev:no-docker` | 1-2 週 | 2-3 |
+| 2 | PoC 5 件 | jwt-alg-none, oauth-state-csrf, rbac-idor, session-fixation, mfa-otp-replay の live 化 | 2 週 | 5 |
+| 3 | A 群残り 13 件 | テーマ別バンドル PR (jwt×3, oauth×1, session×2, rbac×3, oidc×2, sso×3) | 4 週 | 6-7 |
+| 4 | B 群 5 件 | victim-tls-proxy + victim-saml-idp 追加、tls×3 + saml-xsw + pass-the-ticket 実化 | 3 週 | 4-5 |
+| 5 | 整理 | C/D 群バッジ付与、ナレーション型 UI 統合、`is_attack_sim` 削除検討 | 1 週 | 1-2 |
+
+**合計**: 約 11 週
+
+### 5.2 Phase 1 詳細 (インフラ整備)
+
+**Deliverable:**
+
+- `docker-compose.yml` — orchestrator / victim-web / attacker-shell の 3 サービス定義
+- `services/victim-web/` — 新規 Hono アプリ (脆弱エンドポイントスケルトン)
+- `server/routes/orchestrator-exec.ts` — `POST /api/orchestrator/exec` ハンドラ
+- `src/components/shared/RawHttpComposer.tsx` — リクエスト編集 UI
+- `package.json` — `workspaces: ["services/*"]` 追加、`dev:no-docker` スクリプト追加
+- `.github/workflows/ci.yml` — `services:` で victim-web を compose 起動
+
+**リスク**: Windows 環境での Docker Desktop 必須化。`dev:no-docker` フォールバックで Phase 1-2 は
+Docker なしでも既存ナレーション型デモが動作することを保証する。
+
+### 5.3 Phase 2 詳細 (PoC 5 件)
+
+| PoC | victim-web エンドポイント | 検証内容 |
+|-----|--------------------------|---------|
+| jwt-alg-none | `POST /jwt/verify` (request body 内 `{"token": "<JWT>"}`, alg 検証なし) | alg=none JWT で 200 が返ること |
+| oauth-state-csrf | `GET /oauth/authorize` (state 未検証) | state パラメータ省略で認可コード発行されること |
+| rbac-idor | `GET /rbac/resource/:id` (認可なし) | 他ユーザーの id で 200 が返ること |
+| session-fixation | `POST /session/login` (ID 再生成なし) | ログイン後も同一 sid が使えること |
+| mfa-otp-replay | `POST /mfa/verify` (used フラグなし) | 同一 OTP を 2 回送信して両方通ること |
+
+### 5.4 Phase 4 追加コンテナ (案 B 進化)
+
+```yaml
+# docker-compose.yml Phase 4 追加分
+services:
+  victim-tls-proxy:
+    build: services/victim-tls-proxy
+    networks:
+      - victim-net
+    environment:
+      - TLS_VERSION=TLSv1           # TLS 1.0 強制
+      - CIPHER_SUITE=RC4-MD5        # 弱い暗号スイート
+
+  victim-saml-idp:
+    build: services/victim-saml-idp
+    networks:
+      - victim-net
+    environment:
+      - SAML_SIGNING=disabled       # 署名検証省略版
+```
+
+---
+
+## 6. ナレーション型との共存方針
+
+### 6.1 既存ルートの保持
+
+`server/routes/attack-*.ts` の既存 `/attack/<scenario-id>` パスは Phase 5 まで変更しない。
+同一 scenario-id に対して `mode: "narration"` と `mode: "live"` が並存する期間が発生する。
+
+### 6.2 AttackScenarioMeta への mode フィールド追加
+
+DESIGN/03 §1.5 の `AttackScenarioMeta` 型に `mode` フィールドを追加することを提案する。
+
+```typescript
+// shared/api-types.ts への追加提案 (DESIGN/03 §1.5 への拡張)
+export interface AttackScenarioMeta {
+  // ... 既存フィールド ...
+  /** live = 実 victim コンテナと通信 / narration = orchestrator 内部シム */
+  mode: "live" | "narration";
+}
+```
+
+`AttackResult._trace` にも `mode` を伝播させる。
+
+`traceMiddleware.isAttackPath` 判定の orchestrator パス対応は DESIGN/31 §7.1 を参照。
+
+```typescript
+// ServerTrace 拡張 (_trace レスポンス)
+export interface ServerTrace {
+  // ... 既存フィールド ...
+  isAttackMode?: boolean;
+  mode?: "live" | "narration";   // ← 追加
+}
+```
+
+### 6.3 C/D 群の確定方針
+
+C 群 11 件 + D 群 4 件はナレーション型を維持確定とし、Phase 5 で UI バッジを付与する。
+
+| バッジ | 対象 | 色 |
+|-------|------|-----|
+| `LIVE` | A/B 群 live 化完了シナリオ | `#52c41a` (緑) |
+| `SIMULATION` | C 群ナレーション維持 | `#8c8c8c` (グレー) |
+| `DEFENSE DEMO` | D 群失敗デモ | `#1677ff` (青) |
+
+### 6.4 既存テストの維持
+
+`server/__tests__/*-attack.test.ts` 28 ファイルは現行のナレーション型エンドポイントをテストしており、
+live 化の影響を受けない。live 版は `server/__tests__/*-live.test.ts` として別ファイルに追加する。
+
+---
+
+## 7. 開発体験 (DX)
+
+### 7.1 npm scripts
+
+```json
+// package.json (workspaces 追加後)
+{
+  "workspaces": ["services/*"],
+  "scripts": {
+    "dev": "docker compose up -d victim-web attacker-shell && concurrently \"vite\" \"tsx watch server/index.ts\"",
+    "dev:no-docker": "concurrently \"vite\" \"tsx watch server/index.ts\"",
+    "dev:client": "vite",
+    "dev:server": "tsx watch server/index.ts",
+    "build": "tsc && vite build",
+    "victim:reset": "docker compose restart victim-web",
+    "victim:logs": "docker compose logs -f victim-web"
+  }
+}
+```
+
+`dev:no-docker` は Phase 1-2 のみ維持する。Phase 3+ では Docker が必須となり、
+`dev` スクリプトが標準に昇格する。(本ファイル §7.1 を npm scripts の単一正本とする。DESIGN/32 §3 等で言及される dev 関連スクリプトはここを参照)
+
+### 7.2 CI (GitHub Actions)
+
+Phase 1 から CI に Docker を導入する。
+
+```yaml
+# .github/workflows/ci.yml への追加
+jobs:
+  test:
+    services:
+      victim-web:
+        image: ghcr.io/${{ github.repository }}/victim-web:latest
+        ports:
+          - 4001:4001
+    steps:
+      - name: Run orchestrator tests
+        run: npm test
+      - name: Run live attack integration tests
+        run: npm run test:live
+```
+
+victim-web イメージは各 PR でビルドして `ghcr.io` に push する workflow を別途設ける。
+
+### 7.3 ディレクトリ構造 (Phase 1 追加分)
+
+```
+osi-reference/
+├── docker-compose.yml              # Phase 1 追加
+├── package.json                    # workspaces 追加
+├── packages/                       # 将来: WASM 等の共有ライブラリ (現時点空)
+├── services/
+│   ├── victim-web/                 # Phase 1 追加
+│   │   ├── package.json
+│   │   ├── tsconfig.json
+│   │   ├── Dockerfile
+│   │   ├── src/
+│   │   │   ├── index.ts            # Hono アプリ エントリポイント
+│   │   │   ├── routes/
+│   │   │   │   ├── jwt-vuln.ts     # /jwt/verify (alg=none 受理), /jwt/verify-kid
+│   │   │   │   ├── oauth-vuln.ts   # /oauth/authorize (部分一致)
+│   │   │   │   ├── session-vuln.ts # /session/login (ID 再生成なし)
+│   │   │   │   ├── rbac-vuln.ts    # /rbac/resource/:id (認可なし)
+│   │   │   │   └── mfa-vuln.ts     # /mfa/verify (used フラグなし)
+│   │   │   └── db/
+│   │   │       └── victim-schema.ts
+│   │   └── victim-data.sqlite      # gitignored (volume マウント)
+│   └── attacker-shell/             # Phase 1 追加
+│       └── Dockerfile              # Alpine + curl + python3 のみ
+├── server/
+│   ├── routes/
+│   │   ├── orchestrator-exec.ts    # Phase 1 追加: POST /api/orchestrator/exec
+│   │   └── ... (既存 routes)
+│   └── ... (既存)
+└── src/
+    └── components/
+        └── shared/
+            └── RawHttpComposer.tsx # Phase 1 追加
+```
+
+---
+
+## 8. 将来拡張の余地 (L1/L2 深掘り)
+
+### 8.1 services/ の汎用性
+
+`services/` ディレクトリと npm workspaces + docker-compose の構造は、
+攻撃デモ以外の教材モジュールにも適用可能な設計とする。
+
+| 将来追加の候補 | services/ エントリ | 備考 |
+|--------------|-------------------|------|
+| NAND シミュレーター | `services/nand-sim/` | L1 物理層の論理回路教材 |
+| ブレッドボード UI | `services/breadboard-ui/` | L1 配線教材 |
+| NBIT CPU エミュレーター | `services/nbit-cpu/` | L2 データリンク層の ALU 教材 |
+| パケットキャプチャ UI | `services/pcap-viewer/` | L2-L3 教材 |
+
+これらは**現時点では未着手**であり、本シリーズ (DESIGN/30-34) のスコープ外とする。
+`services/` の空ディレクトリ先行作成は行わない (Step A 設計確定後に Step B で実装)。
+
+### 8.2 packages/ の将来計画
+
+```
+packages/
+└── sim-core/     # 将来: WASM ベース sim core 等の共有ライブラリ
+```
+
+`packages/` も現時点では未作成。将来の WASM シミュレーター等の共有ライブラリを
+npm workspaces の `packages/*` として配置できる設計上の余地として確保する。
+
+---
+
+## 9. 安全制約 (DESIGN/04 への参照と差分)
+
+### 9.1 4 原則の live 化における強化
+
+`DESIGN/04-safety-guardrails.md` の 4 原則は live 化においても維持し、一部を強化する。
+
+| 原則 | ナレーション型の実装 | live 型での強化 |
+|------|---------------------|----------------|
+| **隔離** | API 規約で `/api/*` のみに fetch 先を制限 | `victim-net: internal: true` で OS レイヤ egress を物理遮断 |
+| **明示** | `EducationalWarningBanner` + `isAttackMode: true` | `mode: "live"` バッジを DataFlowPanel に追加表示 |
+| **簡略化** | 最終 exploit ステップを省略 | 各 live 化 PR で「`victim-web` 外で再利用できるか?」を必ず問う |
+| **防御策併記** | `AttackDefensePanel` が自動展開 | live 型でも同コンポーネントを継続使用。victim の修正コードも表示 |
+
+### 9.2 新規安全装置の概要
+
+詳細仕様は `DESIGN/34-safety-guardrails-live.md` に分離する。以下に概要を示す。
+
+| 安全装置 | 実装場所 | 目的 |
+|---------|---------|------|
+| `VICTIM_ALLOWLIST` | `server/routes/orchestrator-exec.ts` | `target` パラメータを事前定義済み名前に限定し、任意 URL への転送を防ぐ。target キー名は 1〜32 文字 (DESIGN/31 §3.1 zod スキーマで強制) |
+| `victim-net: internal: true` | `docker-compose.yml` | victim コンテナからのインターネット egress を OS レイヤで遮断 |
+| `--read-only --cap-drop=ALL --pids-limit=64` | attacker-shell コンテナ定義 | attacker-shell の権限を最小化し、ファイルシステム書き込みを禁止 |
+| production guard | `server/routes/orchestrator-exec.ts` | `NODE_ENV === "production"` のとき 503 を返す |
+| `Host` ヘッダ強制上書き | `server/routes/orchestrator-exec.ts` | RawHttpComposer からの `Host` を `victim-web:4001` に強制し DNS rebinding を防ぐ |
+| RawHttpComposer export 無効 | `src/components/shared/RawHttpComposer.tsx` | 組み立てたリクエストのファイル持ち出しボタンを設けない |
+
+### 9.3 禁止表現一覧の継続適用
+
+`DESIGN/04 §2.3` の禁止表現一覧は live 化仕様書・victim-web ソースコード・UI ラベルすべてに適用する。
+特に live 化により「実 HTTP が見える」ことで下記を誘発しやすくなるため注意する。
+
+| 禁止表現 | live 化での誘発シーン |
+|---------|---------------------|
+| 「実環境で試せる」 | RawHttpComposer の説明文 |
+| 「完全な乗っ取り」 | AttackResultBanner の成功表示 |
+| 「ハッキング」 | victim-web ログ出力のラベル |
+
+---
+
+## 関連ファイル
+
+### 本シリーズ (DESIGN/30-34)
+
+| ファイル | 内容 |
+|---------|------|
+| `DESIGN/30-live-attack-architecture.md` | 本ファイル: 全体設計・アーキ選択・ロードマップ |
+| `DESIGN/31-orchestrator-spec.md` | `POST /api/orchestrator/exec` API 仕様・VICTIM_ALLOWLIST 定義 |
+| `DESIGN/32-victim-web-spec.md` | 脆弱 victim-web の全エンドポイント定義・DB スキーマ |
+| `DESIGN/33-raw-http-composer.md` | RawHttpComposer フロント UI 仕様・SolidJS 実装方針 |
+| `DESIGN/34-safety-guardrails-live.md` | DESIGN/04 への live 差分・新規安全装置の詳細実装 |
+
+### 既存 DESIGN ファイル (参照・差分管理)
+
+| ファイル | 本ファイルとの関係 |
+|---------|----------------|
+| `DESIGN/00-overview.md` | ナレーション型カタログ全体。本ファイルはこれを置き換えるのではなく live 化の上位設計として追加 |
+| `DESIGN/01-architecture.md` | ナレーション型バックエンド構成。orchestrator 側は維持。victim-web が新たに追加される |
+| `DESIGN/04-safety-guardrails.md` | 4 原則の基盤。live 型は §9.1 の差分のみ追加し、基盤原則は本ファイルから引用 |
+
+### 実装ファイル (Phase 1 で新規作成)
+
+| ファイルパス | 役割 |
+|------------|------|
+| `docker-compose.yml` | orchestrator / victim-web / attacker-shell サービス定義 |
+| `services/victim-web/src/index.ts` | 脆弱 Hono アプリ エントリポイント |
+| `services/victim-web/Dockerfile` | Node 22 Alpine ベースイメージ |
+| `services/attacker-shell/Dockerfile` | Alpine + curl + python3 最小構成 |
+| `server/routes/orchestrator-exec.ts` | `POST /api/orchestrator/exec` ハンドラ |
+| `src/components/shared/RawHttpComposer.tsx` | リクエスト編集 UI コンポーネント |
+
+### 作業状態
+
+| ファイル | 用途 |
+|---------|------|
+| `CHECKPOINT.md` | Phase ロードマップ・確定意思決定・次アクション |

--- a/DESIGN/31-orchestrator-spec.md
+++ b/DESIGN/31-orchestrator-spec.md
@@ -1,0 +1,627 @@
+---
+title: 攻撃デモカタログ — Orchestrator API 仕様
+phase: design
+audience: 開発者・教材執筆者
+last-updated: 2026-05-02
+safety-reviewed: false
+---
+
+# 31. Orchestrator API 仕様
+
+## 1. 目的とスコープ
+
+### 1.1 エンドポイントの役割
+
+`POST /api/orchestrator/exec` は、ブラウザの `RawHttpComposer` コンポーネントが組み立てた
+raw HTTP リクエストを、`VICTIM_ALLOWLIST` で事前定義された victim コンテナへ中継するプロキシハンドラである。
+
+処理の概要:
+
+1. ブラウザから `{ scenarioId, target, request, timeoutMs }` を受け取る
+2. `target` キーを `VICTIM_ALLOWLIST` で検証し、対応する `baseUrl` を取得する
+3. Node.js 組み込みの `http.request` で victim-net 内部の対象コンテナへ転送する
+4. raw bytes をフルキャプチャし、`elapsedMs` を計測する
+5. `AttackResult` + `_trace (isAttackMode: true, mode: "live")` を整形してブラウザへ返す
+
+### 1.2 既存ナレーション型 `/attack/*` との関係
+
+`DESIGN/30 §6` の共存方針を継承する。
+
+- 既存の `server/routes/<area>.ts` 内 `/attack/<scenario>` ルートは Phase 5 まで残置する。
+- `AttackScenarioMeta.mode` フィールド (`"live" | "narration"`) でフロント側がルーティングを切り替える。
+  - `mode: "live"` → `apiPost("/api/orchestrator/exec", ...)`
+  - `mode: "narration"` → `apiPost("/api/<area>/attack/<scenario>", ...)`
+- Phase 5 でナレーション型を撤去するか否かの最終判断を行う。
+
+### 1.3 本エンドポイントが解決する課題
+
+| 課題 | 解決策 |
+|------|--------|
+| リクエスト生成がサーバー内部に隠蔽されている | 学習者が `RawHttpComposer` でヘッダ・ボディを直接編集してから送信する |
+| HTTP の生のやり取りが不可視 | raw bytes をキャプチャして `DataFlowPanel` に表示する |
+| victim と orchestrator が同居 | victim-web は独立した Docker コンテナとして分離される |
+| 隔離がソフトウェア境界のみ | `victim-net: internal: true` による OS レイヤの egress 遮断で補強する |
+
+---
+
+## 2. エンドポイント仕様
+
+| 項目 | 値 |
+|------|----|
+| メソッド | `POST` |
+| パス | `/api/orchestrator/exec` |
+| Content-Type | `application/json` |
+| 認証 | なし (localhost 限定 + production guard で代替) |
+| タイムアウト | リクエストボディの `timeoutMs` フィールドで制御 (100–10000 ms) |
+| Production 環境 | 503 `live_attack_disabled_in_production` を返す |
+
+Vite proxy 設定 (`/api/*` → `http://localhost:3001`) により、ブラウザからは相対パスでアクセスする。
+
+---
+
+## 3. Request スキーマ (zod)
+
+### 3.1 スキーマ定義
+
+```typescript
+import { z } from "zod";
+
+export const orchestratorExecRequestSchema = z.object({
+  /** AttackScenarioMeta.id と一致させる。例: "jwt-alg-none", "rbac-idor" */
+  scenarioId: z.string().min(1).max(64),
+
+  /** VICTIM_ALLOWLIST のキー文字列。baseUrl は orchestrator が allowlist から取得する。 */
+  target: z.string().min(1).max(32),
+
+  request: z.object({
+    method: z.enum(["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]),
+
+    /** pathname + query string。必ず "/" で始まる。例: "/jwt/protected", "/rbac/resource/2" */
+    path: z.string().regex(/^\//, "path must start with /").max(1024),
+
+    /**
+     * リクエストヘッダ。Host は orchestrator が強制上書きするため、
+     * ブラウザが送ってきた Host 値は無視される (DNS rebinding 予防)。
+     */
+    headers: z.record(z.string(), z.string()),
+
+    /** リクエストボディ。文字列または null。バイナリには未対応 (教育用 HTTP のみ)。 */
+    body: z.union([z.string(), z.null()]).optional(),
+  }),
+
+  /** victim コンテナへの接続タイムアウト (ms)。デフォルト 3000。 */
+  timeoutMs: z.number().int().min(100).max(10000).default(3000),
+});
+
+export type OrchestratorExecRequest = z.infer<typeof orchestratorExecRequestSchema>;
+```
+
+### 3.2 フィールド制約一覧
+
+| フィールド | 型 | 制約 | 代表例 |
+|------------|-----|------|--------|
+| `scenarioId` | string | 1–64 文字 | `"jwt-alg-none"`, `"rbac-idor"` |
+| `target` | string | 1–32 文字、VICTIM_ALLOWLIST のキーのみ有効 | `"victim-web"`, `"attacker-shell"` |
+| `request.method` | enum | 7 種類に限定 | `"GET"`, `"POST"` |
+| `request.path` | string | `/` で始まる、最大 1024 文字 | `"/jwt/protected"`, `"/rbac/resource/2"` |
+| `request.headers` | Record | 任意。`Host` は orchestrator が上書き | `{ "Authorization": "Bearer eyJ..." }` |
+| `request.body` | string \| null | 省略可。バイナリ非対応 | `'{"username":"seed_alice"}'` |
+| `timeoutMs` | integer | 100–10000 ms | `3000` |
+
+### 3.3 エラーケース
+
+| HTTP ステータス | 条件 | レスポンス例 |
+|----------------|------|-------------|
+| 400 | zod スキーマ違反 | `{ error: "schema_validation_failed", _trace: { validationErrors: [...] } }` |
+| 403 | `target` が VICTIM_ALLOWLIST に不在 | `{ error: "target_not_in_allowlist", _trace: { securityNote: "..." } }` |
+| 502 | victim コンテナ到達不能 | `{ error: "victim_unreachable", detail: "ECONNREFUSED" }` |
+| 503 | production mode または Phase 未到達 | `{ error: "live_attack_disabled_in_production" }` |
+| 504 | `timeoutMs` 超過 | `{ error: "victim_timeout", timeoutMs: 3000 }` |
+
+---
+
+## 4. Response スキーマ
+
+### 4.1 OrchestratorExecResponse
+
+```typescript
+import type { AttackResult } from "../../shared/api-types.js";
+
+export interface RawHttpRequest {
+  /** "POST /jwt/verify HTTP/1.1" 形式のリクエスト行 */
+  line: string;
+  headers: Record<string, string>;
+  body: string | null;
+  /** 送信した総バイト数 (ヘッダ + ボディ) */
+  bytesSent: number;
+}
+
+export interface RawHttpResponse {
+  /** "HTTP/1.1 200 OK" 形式のステータス行 */
+  line: string;
+  status: number;
+  headers: Record<string, string>;
+  body: string | null;
+  /** 受信した総バイト数 (ヘッダ + ボディ) */
+  bytesReceived: number;
+}
+
+export interface RawExchange {
+  /** browser ⇄ orchestrator (フロント送信レイヤ) */
+  browserToOrchestrator: {
+    request: RawHttpRequest;
+    response: RawHttpResponse;
+  };
+  /** orchestrator ⇄ victim (内部転送レイヤ) */
+  orchestratorToVictim: {
+    request: RawHttpRequest;
+    response: RawHttpResponse;
+    /** VICTIM_ALLOWLIST から解決された baseUrl */
+    targetResolvedTo: string;
+  };
+  /** browser → orchestrator → victim → orchestrator → browser の総経過 (ms) */
+  elapsedMs: number;
+}
+
+/**
+ * POST /api/orchestrator/exec のレスポンス型。
+ * AttackResult に live モード専用フィールドを追加する。
+ */
+export interface OrchestratorExecResponse extends AttackResult {
+  /**
+   * 双方向 raw HTTP キャプチャ。DataFlowPanel の HTTP/Sequence タブに表示する。
+   * browser⇄orchestrator と orchestrator⇄victim の両ペアをメモリ上のみ保持し、
+   * attack_log テーブルには summary のみ書き込む (raw bytes の永続化禁止)。
+   */
+  rawExchange: RawExchange;
+
+  /** "live" 固定。フロント側が mode バッジを表示するために参照する。 */
+  mode: "live";
+}
+```
+
+`OrchestratorExecResponse` および `RawExchange` 型は `shared/api-types.ts` に追加する (フロント/バックエンド共有のため)。
+
+### 4.2 `_trace` 拡張フィールド
+
+`ServerTrace` に以下の 2 フィールドを追加する。`mode: "live"` の場合にのみ設定される。
+
+```typescript
+// shared/api-types.ts の ServerTrace への追加
+export interface ServerTrace {
+  dbQueries?: DbQuery[];
+  cryptoOps?: CryptoOp[];
+  sessionOps?: SessionOp[];
+  attackSteps?: AttackStep[];
+  isAttackMode?: boolean;
+
+  /** "live" = victim コンテナとの実通信 / "narration" = orchestrator 内部シム (追加) */
+  mode?: "live" | "narration";
+
+  /**
+   * victim 側の内部クエリは orchestrator から観測不能であることを示す注記。
+   * mode: "live" のときのみ設定する。
+   */
+  victimNote?: string;
+}
+```
+
+### 4.3 `AttackStep.kind` 生成ロジック
+
+orchestrator は victim との通信結果をもとに以下の 3 段階のステップを自動組立する。
+
+| ステップ | kind | 説明 |
+|---------|------|------|
+| 1 | `"probe"` | リクエストを victim に送信した事実を記録する |
+| 2 | `"exploit"` | victim が 2xx を返した場合 (攻撃が設計上成立した条件を示す) |
+| 2 (代替) | `"blocked"` | victim が 4xx/5xx を返した場合 (防御が機能したことを示す) |
+| 3 | `"verify"` | 攻撃の成否判定ロジックと防御機構の確認を記録する |
+
+**`AttackResult.outcome` の値設定ルール (live モード)**: live モードでも `outcome` は常に `"succeeded"` を返す (DESIGN/03 §1.4 E-2 既定に準拠)。攻撃成立/失敗の判定は `steps[].kind` (probe/exploit/blocked/verify) および `steps[].status` で表現する。`AttackResultBanner` は最終ステップの `kind === "blocked"` の有無で防御成立を判定する。
+
+---
+
+## 5. VICTIM_ALLOWLIST 構造
+
+### 5.1 型定義
+
+```typescript
+export interface VictimEntry {
+  /**
+   * 転送先 URL。docker-compose の DNS 解決のみで完結する。
+   * 環境変数での上書きは禁止 (§5.3 参照)。
+   * "exec://" で始まる場合は docker exec 経由の実行を示す (attacker-shell 専用)。
+   */
+  baseUrl: string;
+
+  /** この victim が接続する Docker ネットワーク名。 */
+  network: "victim-net";
+
+  /** この victim が利用可能になる最初の Phase 番号。 */
+  phaseAvailable: 1 | 2 | 3 | 4 | 5;
+}
+
+export type VictimTarget =
+  | "victim-web"
+  | "attacker-shell"
+  | "victim-tls-proxy"
+  | "victim-saml-idp";
+
+export const VICTIM_ALLOWLIST: ReadonlyMap<VictimTarget, VictimEntry> = new Map([
+  ["victim-web", {
+    baseUrl: "http://victim-web:4001",
+    network: "victim-net",
+    phaseAvailable: 1,
+  }],
+  ["attacker-shell", {
+    // docker exec 経由。HTTP プロキシではなくコマンド実行に使用する。
+    baseUrl: "exec://attacker-shell",
+    network: "victim-net",
+    phaseAvailable: 1,
+  }],
+  // ── Phase 4 で追加 ─────────────────────────────────────────────────────
+  // ["victim-tls-proxy", {
+  //   baseUrl: "https://victim-tls-proxy:443",
+  //   network: "victim-net",
+  //   phaseAvailable: 4,
+  // }],
+  // ["victim-saml-idp", {
+  //   baseUrl: "http://victim-saml-idp:5000",
+  //   network: "victim-net",
+  //   phaseAvailable: 4,
+  // }],
+]);
+```
+
+### 5.2 Phase 別利用可能性
+
+| target | Phase 1 | Phase 2 | Phase 3 | Phase 4 | Phase 5 |
+|--------|---------|---------|---------|---------|---------|
+| victim-web | 利用可 | 利用可 | 利用可 | 利用可 | 利用可 |
+| attacker-shell | 利用可 | 利用可 | 利用可 | 利用可 | 利用可 |
+| victim-tls-proxy | — | — | — | 利用可 | 利用可 |
+| victim-saml-idp | — | — | — | 利用可 | 利用可 |
+
+`phaseAvailable > currentPhase` の場合、503 `phase_not_reached` を返す。`currentPhase` は環境変数
+`LIVE_ATTACK_PHASE` (デフォルト `1`) で制御する。
+
+### 5.3 URL 偽造防止の設計
+
+- リクエストの `target` フィールドはキー文字列 (`"victim-web"` 等) のみを受け付ける。
+- `baseUrl` は orchestrator が `VICTIM_ALLOWLIST` から取得する。ブラウザから URL を直接指定する手段はない。
+- 環境変数による `baseUrl` の上書きは禁止する。docker-compose の DNS 解決のみで転送先を確定させる。
+- `Host` ヘッダは orchestrator が `baseUrl` の hostname:port から計算して強制上書きする (§6.3 参照)。
+
+---
+
+## 6. raw HTTP プロキシ実装方針
+
+### 6.1 使用モジュール
+
+Node.js 組み込みの `http` モジュールを直接使用する。axios、node-fetch、undici は使用しない。
+理由: raw bytes を `Buffer.concat` でフルキャプチャするために、低レベルな `http.ClientRequest` が必要。
+
+### 6.2 実装擬似コード
+
+```typescript
+import * as http from "node:http";
+import * as https from "node:https";
+
+async function proxyToVictim(
+  entry: VictimEntry,
+  req: OrchestratorExecRequest["request"],
+  timeoutMs: number,
+): Promise<{ exchange: RawExchange }> {
+  const base = new URL(entry.baseUrl);
+  const isHttps = base.protocol === "https:";
+  const transport = isHttps ? https : http;
+  const startedAt = Date.now();
+
+  // Host ヘッダを allowlist の baseUrl から計算して強制上書きする
+  const forcedHeaders: Record<string, string> = {
+    ...req.headers,
+    Host: base.host,           // DNS rebinding 予防
+    Connection: "close",
+  };
+  if (req.body) {
+    forcedHeaders["Content-Length"] = String(Buffer.byteLength(req.body, "utf8"));
+  }
+
+  return new Promise((resolve, reject) => {
+    const clientReq = transport.request({
+      hostname: base.hostname,
+      port: base.port || (isHttps ? 443 : 80),
+      path: req.path,
+      method: req.method,
+      headers: forcedHeaders,
+    });
+
+    clientReq.setTimeout(timeoutMs, () => {
+      clientReq.destroy(new Error("victim_timeout"));
+    });
+
+    const responseChunks: Buffer[] = [];
+    clientReq.on("response", (res) => {
+      res.on("data", (chunk: Buffer) => responseChunks.push(chunk));
+      res.on("end", () => {
+        const rawBody = Buffer.concat(responseChunks);
+        const elapsedMs = Date.now() - startedAt;
+        resolve({
+          exchange: {
+            request: {
+              line: `${req.method} ${req.path} HTTP/1.1`,
+              headers: forcedHeaders,
+              body: req.body ?? null,
+              bytesSent: /* ヘッダ文字列 + ボディ */ rawBody.length,
+            },
+            response: {
+              line: `HTTP/1.1 ${res.statusCode} ${res.statusMessage}`,
+              status: res.statusCode ?? 0,
+              headers: res.headers as Record<string, string>,
+              body: rawBody.toString("utf8"),
+              bytesReceived: rawBody.length,
+            },
+            elapsedMs,
+            targetResolvedTo: entry.baseUrl,
+          },
+        });
+      });
+    });
+
+    clientReq.on("error", reject);
+    if (req.body) clientReq.write(req.body);
+    clientReq.end();
+  });
+}
+```
+
+### 6.3 `Host` ヘッダ強制上書き
+
+ブラウザが送信した `Host` 値は無条件で破棄し、`VICTIM_ALLOWLIST[target].baseUrl` の
+hostname:port を使用する。これにより DNS rebinding 攻撃の経路を物理的に閉じる。
+
+### 6.4 bytes キャプチャポリシー
+
+- browser⇄orchestrator と orchestrator⇄victim の**双方向** raw bytes を独立してキャプチャする。
+  両ペアともメモリ上でのみ保持し、レスポンスとして一度だけ返す。
+- `attack_log` テーブルには `scenarioId`, `outcome`, `elapsedMs`, `targetResolvedTo` の
+  summary のみ書き込む。`rawExchange` の完全な bytes (双方向分) は永続化しない (ROB-FIND 対策)。
+
+---
+
+## 7. `_trace` 整形 (middleware 拡張)
+
+### 7.1 既存 `trace-logger.ts` への変更点
+
+`traceContext` に `mode` フィールドを追加する。`isAttackMode` は既存実装のまま流用する。
+
+```typescript
+// server/middleware/trace-logger.ts への変更
+
+// ① TraceCollector インタフェースに setLiveMode() を追加
+export interface TraceCollector {
+  addDbQuery(q: DbQuery): void;
+  addCryptoOp(op: CryptoOp): void;
+  addSessionOp(op: SessionOp): void;
+  addAttackStep(step: AttackStep | Omit<AttackStep, "timestamp">): void;
+  /** orchestrator/exec ルートが呼び出す。mode: "live" を _trace に付与する。 */
+  setLiveMode(): void;
+  getTrace(): ServerTrace;
+}
+
+// ② createTraceCollector() 内部に mode フラグを追加
+function createTraceCollector(): TraceCollector {
+  let liveMode = false;
+  // ... 既存の配列定義は変更なし ...
+  return {
+    // ... 既存メソッドは変更なし ...
+    setLiveMode() { liveMode = true; },
+    getTrace() {
+      const trace: ServerTrace = {};
+      // ... 既存フィールド付与は変更なし ...
+      if (liveMode) {
+        trace.mode = "live";
+        trace.victimNote =
+          "victim コンテナ内部の DB クエリ・暗号操作は orchestrator から観測不能です";
+      }
+      return trace;
+    },
+  };
+}
+
+// ③ traceMiddleware の isAttackMode 判定に orchestrator パスを追加
+const isAttackPath =
+  ctx.req.path.includes("/attack/") ||
+  ctx.req.path.startsWith("/api/orchestrator/");
+```
+
+### 7.2 victim 側 `_trace` の不可視性
+
+orchestrator は victim コンテナとの通信を HTTP プロキシとして行うため、
+victim 内部で発生した DB クエリ・暗号操作は `_trace` に含まれない。
+`_trace.victimNote` にその旨を明示し、学習者が「なぜ victim の内部クエリが見えないか」
+を理解できるよう補足する。
+
+---
+
+## 8. Production guard
+
+### 8.1 動作仕様
+
+`process.env.NODE_ENV === "production"` の場合、`/api/orchestrator/*` へのすべてのリクエストに
+503 を返す。本機能は教育用ローカル環境専用であり、誤って本番デプロイされた場合の防護線とする。
+
+```typescript
+// server/middleware/production-guard.ts (新規作成)
+import type { Context, Next } from "hono";
+
+export async function productionGuard(ctx: Context, next: Next) {
+  if (process.env.NODE_ENV === "production") {
+    return ctx.json(
+      { success: false, error: "live_attack_disabled_in_production" },
+      503,
+    );
+  }
+  await next();
+}
+```
+
+### 8.2 登録位置
+
+`server/index.ts` でルート登録前に `productionGuard` を適用する。
+
+```typescript
+// server/index.ts への追加
+import { productionGuard } from "./middleware/production-guard.js";
+import { orchestratorExecRoutes } from "./routes/orchestrator-exec.js";
+
+app.use("/api/orchestrator/*", productionGuard);
+app.route("/api/orchestrator", orchestratorExecRoutes);
+```
+
+`/api/<area>/attack/*` 既存ルートは別途 `NODE_ENV !== "production"` ガードを適用済 (該当箇所は実装時に確認)。
+`/api/orchestrator/*` 専用の独立したガードとして定義することで役割を明確に分離する。
+
+---
+
+## 9. エラーハンドリング
+
+### 9.1 エラーコード一覧
+
+| HTTP | エラーコード | 発生条件 | `_trace` への記録 |
+|------|-------------|---------|------------------|
+| 400 | `schema_validation_failed` | zod バリデーション違反 | `validationErrors: ZodIssue[]` |
+| 403 | `target_not_in_allowlist` | `target` が VICTIM_ALLOWLIST に存在しない | `securityNote: "不正な target 値の可能性あり"` |
+| 502 | `victim_unreachable` | コンテナ未起動、ネットワーク不通 (ECONNREFUSED / ENOTFOUND) | `detail: err.message` |
+| 503 | `live_attack_disabled_in_production` | `NODE_ENV === "production"` | なし |
+| 503 | `phase_not_reached` | `phaseAvailable > currentPhase` | `requiredPhase`, `currentPhase` |
+| 504 | `victim_timeout` | `timeoutMs` 超過 | `timeoutMs: number` |
+
+### 9.2 403 の特別扱い
+
+`target` が VICTIM_ALLOWLIST に存在しない場合は URL 偽造試行の可能性があるため、
+`_trace.securityNote` に記録するとともに orchestrator サーバーのログに WARNING レベルで出力する。
+レスポンスに `target` の実際の値は含めない (情報漏洩防止)。
+
+### 9.3 502 のユーザー向けメッセージ
+
+```typescript
+// DataFlowPanel で表示するヒントメッセージ
+const victimUnreachableHint = t(
+  "victim コンテナに到達できません。`npm run dev` または `docker compose up` を実行してください。",
+  "Cannot reach victim container. Run `npm run dev` or `docker compose up`.",
+);
+```
+
+---
+
+## 10. 共存方針 (既存ナレーション型 `/attack/*` との関係)
+
+### 10.1 フロント側のルーティング切り替え
+
+`AttackScenarioMeta` に `mode` フィールドを追加し (DESIGN/30 §6.2 の提案を正式採用)、
+フロントが呼び出し先を動的に切り替える。
+
+```typescript
+// shared/api-types.ts の AttackScenarioMeta への追加
+export interface AttackScenarioMeta {
+  // ... 既存フィールド ...
+
+  /**
+   * "live"     : Docker victim コンテナと実通信 → /api/orchestrator/exec
+   * "narration": orchestrator 内部シム → /api/<area>/attack/<scenario>
+   */
+  mode: "live" | "narration";
+}
+```
+
+```typescript
+// AttackPanel.tsx での切り替えロジック (概念)
+async function runAttack(scenario: AttackScenarioMeta) {
+  if (scenario.mode === "live") {
+    const res = await apiPost<OrchestratorExecResponse>(
+      "/api/orchestrator/exec",
+      { scenarioId: scenario.id, target: "victim-web", request: composedRequest() },
+      SCOPE,
+    );
+    setCurrentResult(res.data);
+  } else {
+    const res = await apiPost<AttackResult>(scenario.apiPath, params, SCOPE);
+    setCurrentResult(res.data);
+  }
+}
+```
+
+### 10.2 バッジ表示
+
+`mode: "live"` のシナリオには DataFlowPanel に `LIVE` バッジ (`#52c41a`) を表示する。
+`mode: "narration"` のシナリオには `SIMULATION` バッジ (`#8c8c8c`) を表示する。
+
+### 10.3 Phase 5 での整理方針
+
+Phase 5 では `mode === "narration"` のシナリオを再評価し、live 化が可能なものと
+ナレーション型を維持するものを最終決定する (C/D 区分はナレーション維持確定)。
+
+---
+
+## 11. テスト要件
+
+### 11.1 vitest + supertest テストチェックリスト
+
+実装担当者は以下のテストを `server/__tests__/orchestrator-live.test.ts` に追加する。
+
+- [ ] スキーマ違反 (必須フィールド欠如) → 400 + `validationErrors` を返す
+- [ ] `target` が VICTIM_ALLOWLIST に不在 → 403 + `_trace.securityNote` が設定されている
+- [ ] victim コンテナ未起動 (ECONNREFUSED) → 502 + `detail` にエラーメッセージが含まれる
+- [ ] `timeoutMs: 100` でタイムアウト → 504 + `timeoutMs: 100` が返る
+- [ ] `NODE_ENV=production` で起動 → 503 `live_attack_disabled_in_production` を返す
+- [ ] 正常系: browser → orchestrator の raw bytes (`rawExchange.browserToOrchestrator`) と orchestrator → victim の raw bytes (`rawExchange.orchestratorToVictim`) が両方独立してキャプチャされる
+- [ ] 正常系: レスポンスの `rawExchange.orchestratorToVictim.request.headers.Host` が victim の baseUrl から計算した値に強制上書きされている
+- [ ] 正常系: `attack_log` には `scenarioId`, `outcome`, `elapsedMs` の summary のみ書かれ、`rawExchange` の双方向生データは含まれない
+- [ ] 正常系: `_trace.mode === "live"` が設定されている
+- [ ] 正常系: `_trace.victimNote` が設定されている
+
+### 11.2 モック方針
+
+victim コンテナへの HTTP 通信は `nock` または `http.createServer` で in-process にモックする。
+実際の docker compose 起動は `test:live` スクリプト (CI 用) でのみ行う。
+
+```json
+// package.json (追加分)
+{
+  "scripts": {
+    "test": "vitest",
+    "test:live": "LIVE_ATTACK_PHASE=1 vitest --project=live"
+  }
+}
+```
+
+---
+
+## 関連ファイル
+
+### 本シリーズ (DESIGN/30–34)
+
+| ファイル | 内容 |
+|---------|------|
+| `DESIGN/30-live-attack-architecture.md` | 全体設計・アーキ選択・ロードマップ (本仕様の上流) |
+| `DESIGN/31-orchestrator-spec.md` | 本ファイル |
+| `DESIGN/32-victim-web-spec.md` | 本仕様の `target` で参照される victim-web の全エンドポイント定義 |
+| `DESIGN/33-raw-http-composer.md` | 本仕様の Request を組み立てるフロントの UI 仕様 |
+| `DESIGN/34-safety-guardrails-live.md` | 本仕様が依拠する安全装置の詳細実装 |
+
+### 既存ファイル (拡張対象)
+
+| ファイルパス | 変更内容 |
+|------------|---------|
+| `shared/api-types.ts` | `ServerTrace` に `mode`, `victimNote` を追加。`AttackScenarioMeta` に `mode` を追加 |
+| `server/middleware/trace-logger.ts` | `TraceCollector` に `setLiveMode()` を追加。`getTrace()` で `mode: "live"` と `victimNote` を付与 |
+| `server/index.ts` | `productionGuard` ミドルウェアを `/api/orchestrator/*` に登録。`orchestratorExecRoutes` を追加 |
+
+### Phase 1 で新規作成するファイル
+
+| ファイルパス | 役割 |
+|------------|------|
+| `server/routes/orchestrator-exec.ts` | `POST /api/orchestrator/exec` ハンドラ本体 |
+| `server/middleware/production-guard.ts` | `NODE_ENV === "production"` ガード |
+| `server/__tests__/orchestrator-live.test.ts` | 本仕様のユニット・統合テスト |

--- a/DESIGN/32-victim-web-spec.md
+++ b/DESIGN/32-victim-web-spec.md
@@ -1,0 +1,678 @@
+---
+title: 攻撃デモカタログ — victim-web 脆弱アプリ仕様
+phase: design
+audience: 開発者・教材執筆者
+last-updated: 2026-05-02
+safety-reviewed: false
+---
+
+## 教育目的
+
+本ファイルは **教育用シミュレーション** の実装設計である。
+記載された脆弱エンドポイントは `victim-net (internal: true)` 内の固定シードデータに対してのみ動作するよう設計されており、
+実環境への攻撃を意図したものではない。
+
+各エンドポイントの脆弱実装は「この防御がなぜ必要か」を体感するための概念実証であり、
+必ず堅牢実装 (`server/routes/*.ts`) との対応関係を併記する。
+
+---
+
+# 32. victim-web 脆弱アプリ仕様
+
+## 1. 目的とスコープ
+
+### 1.1 役割
+
+`services/victim-web/` は orchestrator (`server/routes/orchestrator-exec.ts` の `POST /api/orchestrator/exec`) から
+実 HTTP リクエストを受け取り、**意図的に脆弱な実装**で応答する独立 Hono アプリである。
+
+学習者は `RawHttpComposer` でヘッダ・ボディを自ら編集し、orchestrator 経由で victim-web に実 HTTP を送信することで、
+脆弱性が成立する条件を体感できる。victim-web が「攻撃が成立した」応答を返すことで、
+DataFlowPanel に rawRequest / rawResponse が表示され、教育効果が生まれる。
+
+orchestrator は `VICTIM_ALLOWLIST` で到達先を `victim-web:4001` のみに制限し、
+任意の外部 URL への転送は設計上不可能である。
+
+### 1.2 隔離方針
+
+- **ネットワーク**: `victim-net` (`internal: true`) にのみ接続。Docker が OS レイヤでインターネット egress を遮断する
+- **DB 分離**: `victim-data.sqlite` を独立 Docker volume (`victim-db`) に配置。orchestrator の `server/db/data.sqlite` とは物理的に別ファイル
+- **対象ユーザー**: シードユーザー (`seed_alice`, `seed_bob`, `seed_admin`, `attacker_charlie`) のみ。任意ユーザーデータへの攻撃は設計上不可能
+- **egress なし**: victim-web コンテナ自体が外部 URL に fetch することはない
+
+### 1.3 スコープ範囲
+
+| Phase | 担当コンテナ | 対象区分 |
+|-------|------------|--------|
+| Phase 1-3 | `victim-web` (本仕様) | A 群 18 シナリオ |
+| Phase 4 | `victim-tls-proxy` (nginx + 旧 TLS) | B 群: tls-version-downgrade, tls-self-signed-mitm, tls-weak-cipher |
+| Phase 4 | `victim-saml-idp` (独自実装) | B 群: saml-xsw, pass-the-ticket |
+
+Phase 4 の 2 コンテナは **本仕様のスコープ外**とする。仕様は別途 `DESIGN/35-victim-tls-proxy.md`、`DESIGN/36-victim-saml-idp.md` で定義する。
+
+---
+
+## 2. `services/victim-web/` ディレクトリ構造
+
+```
+services/victim-web/
+├── package.json              # 独立 package、name: "@osi-ref/victim-web"
+├── Dockerfile                # node:20-alpine ベース
+├── tsconfig.json             # extends ../../tsconfig.base.json
+├── src/
+│   ├── index.ts              # Hono エントリ、全ルート登録 + /health + /api/reset
+│   ├── seed.ts               # シードユーザー投入 (seed_alice, seed_bob, seed_admin, attacker_charlie)
+│   ├── db.ts                 # better-sqlite3 初期化、victim-data.sqlite を /app/data/ に配置
+│   └── routes/
+│       ├── jwt.ts            # /jwt/verify, /jwt/verify-kid, /jwt/issue-weak
+│       ├── rbac.ts           # /orders/:id, /users/:id, /admin/:action, /resource
+│       ├── session.ts        # /session/login, /session/me, /token/refresh
+│       ├── oauth.ts          # /oauth/authorize, /oauth/redirect
+│       ├── oidc.ts           # /oidc/verify-id-token
+│       ├── saml.ts           # /saml/consume-assertion
+│       ├── mfa.ts            # /mfa/verify
+│       └── sso.ts            # /api/resource, /api/hmac, /api/replay
+└── __tests__/
+    ├── jwt.test.ts
+    ├── rbac.test.ts
+    ├── session.test.ts
+    ├── oauth.test.ts
+    ├── oidc-saml.test.ts
+    ├── mfa.test.ts
+    └── sso.test.ts
+```
+
+> **注意**: `victim-data.sqlite` はコンテナ内 `/app/data/` に配置し、compose の `tmpfs` マウントで管理する。
+> gitignore 対象であり、`src/` 配下には含めない。
+
+---
+
+## 3. npm workspaces 統合
+
+### 3.1 root `package.json` への変更
+
+```json
+{
+  "name": "osi-reference",
+  "private": true,
+  "workspaces": ["services/*"],
+  "scripts": {
+    "dev": "docker compose up -d victim-web attacker-shell && concurrently \"vite\" \"tsx watch server/index.ts\"",
+    "dev:no-docker": "concurrently \"vite\" \"tsx watch server/index.ts\"",
+    "dev:client": "vite",
+    "dev:server": "tsx watch server/index.ts",
+    "build": "vite build",
+    "victim:reset": "docker compose restart victim-web",
+    "victim:logs": "docker compose logs -f victim-web"
+  }
+}
+```
+
+### 3.2 `services/victim-web/package.json`
+
+```json
+{
+  "name": "@osi-ref/victim-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.19.13",
+    "better-sqlite3": "^12.8.0",
+    "bcryptjs": "^3.0.3",
+    "hono": "^4.12.12",
+    "jsonwebtoken": "^9.0.3",
+    "uuid": "^13.0.0"
+  },
+  "peerDependencies": {
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.2"
+  }
+}
+```
+
+### 3.3 型共有方針
+
+- `shared/api-types.ts` の型 (`ServerTrace` 等) を `services/victim-web/` から import 可能とする (型のみ。実装コードは持ち込まない)
+- workspaces の単一 root `package-lock.json` でロックファイルを一元管理する
+- victim-web 固有の実装依存 (`@simplewebauthn/*`, `d3-*` 等) は持ち込まない
+
+---
+
+## 4. Phase 1-3 脆弱エンドポイント定義 (A 群 18 シナリオ対応)
+
+### 4.1 JWT 系
+
+#### 4.1.1 エンドポイント一覧
+
+| URL | シナリオ ID | CWE | 攻撃ペイロード例 | 期待挙動 | 堅牢実装 |
+|-----|------------|-----|----------------|---------|---------|
+| `POST /jwt/verify` | jwt-alg-none, jwt-signature-stripping | CWE-345, CWE-347 | `Authorization: Bearer eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWVkX2FsaWNlIiwicm9sZSI6ImFkbWluIn0.` | 200 + `{"valid":true,"claims":{...}}` | `server/routes/jwt-ops.ts` `POST /api/jwt/verify` |
+| `POST /jwt/verify-kid` | jwt-kid-injection | CWE-22, CWE-90 | `{"token":"...", "kid":"../../etc/passwd"}` | 200 (パストラバーサル後の内容でキー解決を試みる) | `server/routes/jwt-ops.ts` (kid を allowlist で制限) |
+| `POST /jwt/issue-weak` | jwt-weak-secret-bruteforce | CWE-326 | `{"sub":"seed_alice","role":"user"}` | 200 + 弱秘密鍵 (`"secret"`) で署名したトークン | `server/routes/jwt-ops.ts` `POST /api/jwt/sign` (強秘密鍵使用) |
+
+#### 4.1.2 `POST /jwt/verify` 脆弱実装コード例
+
+```typescript
+// services/victim-web/src/routes/jwt.ts
+// これは CWE-345 / CWE-347 の概念実証です。
+// algorithms オプションを省略することで alg=none および署名ストリッピングが成立する。
+
+import jwt from "jsonwebtoken";
+import { Hono } from "hono";
+
+const WEAK_SECRET = "secret"; // 教材用弱秘密鍵 — 本番環境では絶対に使用しないこと
+
+export const jwtRoutes = new Hono();
+
+// 脆弱: algorithms 未指定 → alg=none / 署名ストリッピングを受理する
+jwtRoutes.post("/jwt/verify", async (c) => {
+  const { token } = await c.req.json<{ token: string }>();
+  try {
+    // algorithms オプションを渡さない — これが脆弱性の核心
+    const decoded = jwt.verify(token, WEAK_SECRET);
+    return c.json({ valid: true, claims: decoded });
+  } catch (err) {
+    return c.json({ valid: false, error: String(err) }, 401);
+  }
+});
+
+// 脆弱: kid をファイルパスとして直接使用 (CWE-22 パストラバーサル)
+jwtRoutes.post("/jwt/verify-kid", async (c) => {
+  const { token, kid } = await c.req.json<{ token: string; kid: string }>();
+  try {
+    const fs = await import("node:fs");
+    // kid をサニタイズせずにファイルパスとして使用する — パストラバーサルが成立する
+    const keyMaterial = fs.readFileSync(`/app/keys/${kid}`, "utf-8");
+    const decoded = jwt.verify(token, keyMaterial, { algorithms: ["RS256"] });
+    return c.json({ valid: true, claims: decoded });
+  } catch (err) {
+    return c.json({ valid: false, error: String(err) }, 401);
+  }
+});
+
+// 弱秘密鍵でトークンを発行 (ブルートフォース攻撃のターゲット生成)
+jwtRoutes.post("/jwt/issue-weak", async (c) => {
+  const { sub, role } = await c.req.json<{ sub: string; role: string }>();
+  const token = jwt.sign({ sub, role }, WEAK_SECRET, { algorithm: "HS256", expiresIn: "1h" });
+  return c.json({ token, note: "教材用弱秘密鍵で署名済み" });
+});
+```
+
+> **簡略化方針 (DESIGN/04 §1.3)**: kid パストラバーサルは `/app/keys/` 配下のファイル読み込みのみを示す。
+> 実際のシェル実行や任意コード実行には至らない最小実装にとどめる。
+
+### 4.2 RBAC 系
+
+| URL | シナリオ ID | CWE | 攻撃ペイロード例 | 期待挙動 | 堅牢実装 |
+|-----|------------|-----|----------------|---------|---------|
+| `GET /orders/:id` | rbac-idor, rbac-horizontal-privesc | CWE-639 | `GET /orders/2` (seed_bob の注文を seed_alice が取得) | 200 + 他ユーザーのデータ | `server/routes/rbac.ts` `GET /api/rbac/orders/:id` |
+| `GET /users/:id` | rbac-horizontal-privesc | CWE-639 | `GET /users/3` (seed_admin のプロフィールを一般ユーザーが取得) | 200 + 任意ユーザー情報 | `server/routes/rbac.ts` (所有者確認あり) |
+| `POST /admin/:action` | rbac-vertical-privesc | CWE-285 | `{"token":"eyJ...role:admin改竄済み..."}` + `POST /admin/list-users` | 200 + 管理者操作結果 | `server/routes/rbac.ts` (role クレーム DB 照合) |
+| `POST /resource` | rbac-abac-tampering | CWE-807 | `X-Department: finance` ヘッダを付与して送信 | 200 + finance リソースへのアクセス | `server/routes/rbac.ts` `POST /api/rbac/check` (ABAC ルール検証) |
+
+**`GET /orders/:id` 脆弱実装の核心:**
+
+```typescript
+// 脆弱: 呼び出し元 user_id と :id の所有者確認を一切行わない (CWE-639)
+rbacRoutes.get("/orders/:id", (c) => {
+  const id = c.req.param("id");
+  const row = db.prepare("SELECT * FROM victim_orders WHERE id = ?").get(id);
+  if (!row) return c.json({ error: "Not found" }, 404);
+  return c.json({ data: row }); // 認可チェックなしにデータを返す
+});
+```
+
+### 4.3 Session 系
+
+| URL | シナリオ ID | CWE | 攻撃ペイロード例 | 期待挙動 | 堅牢実装 |
+|-----|------------|-----|----------------|---------|---------|
+| `POST /session/login` | session-fixation | CWE-384 | `{"username":"seed_alice","password":"Passw0rd!","sid":"attacker-chosen-sid"}` | 200 + `Set-Cookie: sid=attacker-chosen-sid` (body の sid をそのまま Cookie にセット) | `server/routes/session-auth.ts` `POST /api/session/login` (UUID v4 を新規生成) |
+| `GET /session/me` | session-xss-cookie-steal | CWE-1004 | Cookie: `sid=<有効なセッション>` | 200 + `Set-Cookie: sid=...; Path=/` (HttpOnly 属性なし) | `server/routes/session-auth.ts` (`httpOnly: true` 付与) |
+| `POST /token/refresh` | session-token-replay | CWE-294 | 同一 `{"jti":"<使用済み jti>"}` を 2 回送信 | 両リクエストとも 200 + 新しいアクセストークン | `server/routes/token-auth.ts` (jti の使用済み検出) |
+
+**`POST /session/login` 脆弱実装の核心:**
+
+```typescript
+// 脆弱: リクエスト body の sid を Set-Cookie にそのまま使用 (CWE-384 セッション固定)
+sessionRoutes.post("/session/login", async (c) => {
+  const { username, password, sid } = await c.req.json<{
+    username: string; password: string; sid?: string;
+  }>();
+  const user = db.prepare("SELECT * FROM victim_users WHERE username = ?").get(username);
+  if (!user || !bcrypt.compareSync(password, (user as any).password_hash)) {
+    return c.json({ error: "Invalid credentials" }, 401);
+  }
+  // 攻撃者が指定した sid をそのまま Cookie にセット — 認証後の再生成を行わない
+  const sessionId = sid ?? uuidv4();
+  setCookie(c, "sid", sessionId, { path: "/", sameSite: "Lax" }); // HttpOnly なし
+  return c.json({ ok: true, sessionId });
+});
+```
+
+### 4.4 OAuth 系
+
+| URL | シナリオ ID | CWE | 攻撃ペイロード例 | 期待挙動 | 堅牢実装 |
+|-----|------------|-----|----------------|---------|---------|
+| `GET /oauth/authorize` | oauth-state-csrf | CWE-352 | `GET /oauth/authorize?client_id=demo&redirect_uri=http://localhost:3000/callback` (state パラメータなし) | 200 + 認可コード発行 (state 検証なし) | `server/routes/oauth-sim.ts` `GET /api/oauth/authorize` (state 必須検証) |
+| `POST /oauth/redirect` | oauth-redirect-uri-bypass | CWE-601 | `{"redirect_uri":"http://localhost:3000.evil.example/callback"}` | 200 + 認可コードを evil.example に転送 (startsWith 部分一致) | `server/routes/oauth-sim.ts` (完全一致 allowlist 検証) |
+
+**`POST /oauth/redirect` 脆弱実装の核心:**
+
+```typescript
+// 脆弱: redirect_uri の検証を startsWith で行う (CWE-601 オープンリダイレクト)
+oauthRoutes.post("/oauth/redirect", async (c) => {
+  const { redirect_uri, code } = await c.req.json<{ redirect_uri: string; code: string }>();
+  const ALLOWED_PREFIX = "http://localhost:3000";
+  // startsWith は "http://localhost:3000.evil.example/" も通してしまう
+  if (!redirect_uri.startsWith(ALLOWED_PREFIX)) {
+    return c.json({ error: "Invalid redirect_uri" }, 400);
+  }
+  return c.redirect(`${redirect_uri}?code=${code}`);
+});
+```
+
+### 4.5 OIDC/SAML 系 (Phase 3 / A 群 2 件)
+
+| URL | シナリオ ID | CWE | 攻撃ペイロード例 | 期待挙動 | 堅牢実装 |
+|-----|------------|-----|----------------|---------|---------|
+| `POST /oidc/verify-id-token` | oidc-id-token-spoofing | CWE-290, CWE-347 | `{"id_token":"eyJ...aud:evil-client,iss:attacker.example..."}` | 200 + `{"valid":true}` (aud/iss 無検証) | `server/routes/oidc-saml-sim.ts` (aud/iss を expected 値と照合) |
+| `POST /saml/consume-assertion` | saml-assertion-replay | CWE-294 | 過去の有効な SAML アサーション (NotOnOrAfter 超過) を 2 回 POST | 両リクエストとも 200 (NotOnOrAfter / InResponseTo 無検証) | `server/routes/oidc-saml-sim.ts` (NotOnOrAfter + InResponseTo + 使用済み ID 検出) |
+
+**`POST /oidc/verify-id-token` 脆弱実装の核心:**
+
+```typescript
+// 脆弱: aud (audience) および iss (issuer) を検証しない (CWE-290)
+oidcRoutes.post("/oidc/verify-id-token", async (c) => {
+  const { id_token } = await c.req.json<{ id_token: string }>();
+  try {
+    // jwt.decode はシグネチャ検証なしでクレームを読むだけ
+    const claims = jwt.decode(id_token) as Record<string, unknown>;
+    // aud / iss の検証を完全に省略 — 任意の IdP のトークンを受け入れる
+    return c.json({ valid: true, claims });
+  } catch {
+    return c.json({ valid: false }, 401);
+  }
+});
+```
+
+### 4.6 MFA 系
+
+| URL | シナリオ ID | CWE | 攻撃ペイロード例 | 期待挙動 | 堅牢実装 |
+|-----|------------|-----|----------------|---------|---------|
+| `POST /mfa/verify` | mfa-otp-replay | CWE-294, CWE-308 | 同一 OTP (`{"otp":"123456"}`) を連続 2 回 POST | 両リクエストとも 200 + `{"ok":true}` (使用済みフラグなし) | `server/routes/mfa-totp.ts` (`used_otps` テーブルで重複検出) |
+
+**脆弱実装の核心 (使用済みフラグを持たない):**
+
+```typescript
+// 脆弱: OTP の使用済み記録をしない (CWE-294 リプレイ攻撃が成立)
+mfaRoutes.post("/mfa/verify", async (c) => {
+  const { otp, username } = await c.req.json<{ otp: string; username: string }>();
+  const user = db.prepare("SELECT * FROM victim_users WHERE username = ?").get(username) as any;
+  if (!user) return c.json({ ok: false }, 401);
+  // 固定 OTP シークレットとの TOTP 照合のみ。used フラグ / nonce テーブルなし
+  const isValid = verifyTotp(otp, user.totp_secret);
+  return c.json({ ok: isValid }); // 同じ OTP で何度でも通る
+});
+```
+
+### 4.7 SSO/APIKey 系
+
+| URL | シナリオ ID | CWE | 攻撃ペイロード例 | 期待挙動 | 堅牢実装 |
+|-----|------------|-----|----------------|---------|---------|
+| `GET /api/resource?api_key=xxx` | sso-apikey-leakage | CWE-598, CWE-200 | `GET /api/resource?api_key=seed-key-abc123` | 200 + リソースデータ (URL クエリのキーが access_log に残る) | `server/routes/sso-apikey.ts` (Authorization ヘッダのみ受理) |
+| `POST /api/hmac` | sso-hmac-bypass | CWE-345 | `X-Signature` ヘッダなしで POST | 200 + `{"ok":true}` (HMAC 検証完全省略) | `server/routes/sso-apikey.ts` (HMAC-SHA256 検証必須) |
+| `POST /api/replay` | sso-replay-no-timestamp | CWE-294 | 同一タイムスタンプのリクエストを 2 回 POST | 両リクエストとも 200 (タイムスタンプ・nonce 検証なし) | `server/routes/sso-apikey.ts` (timestamp ±30 秒 + replay_nonce テーブル) |
+
+**`GET /api/resource` 脆弱実装の核心:**
+
+```typescript
+// 脆弱: API キーをクエリパラメータで受理 (CWE-598 — URL が access_log / Referer ヘッダに漏洩)
+ssoRoutes.get("/api/resource", (c) => {
+  const apiKey = c.req.query("api_key"); // クエリパラメータで受け取る
+  if (!apiKey) return c.json({ error: "api_key required" }, 401);
+  const row = db.prepare("SELECT * FROM victim_api_keys WHERE key_value = ?").get(apiKey);
+  if (!row) return c.json({ error: "Invalid key" }, 403);
+  return c.json({ data: "protected resource", owner: (row as any).username });
+});
+```
+
+---
+
+## 5. シードデータ (`src/seed.ts`)
+
+### 5.1 シードユーザー定義
+
+DESIGN/04 §5.1 の規約に従い、以下の固定シードユーザーのみを対象とする。
+
+| 識別子 | パスワード (固定・教材用) | role | 用途 |
+|-------|----------------------|------|------|
+| `seed_alice` | `Passw0rd!` | user | セッション固定・トークン窃取の被害者 |
+| `seed_bob` | `hunter2` | user | 権限昇格攻撃の起点 |
+| `seed_admin` | `admin` | admin | 権限昇格の到達目標 |
+| `attacker_charlie` | `attacker` | user | 攻撃リクエストの送信者 |
+
+> **免責**: 上記パスワードは「弱いパスワードがなぜ危険か」を体感させる教材専用の固定値である。
+> `seed_*` というプレフィックスにより実運用ユーザーとの混同を防ぐ (DESIGN/04 §2.3)。
+> bcrypt rounds は教材用低コスト設定 (rounds=4) を使用する。本番環境では 12 以上を推奨。
+
+### 5.2 `src/seed.ts` 実装例
+
+```typescript
+// services/victim-web/src/seed.ts
+// 【教育目的専用】固定シードデータ — 実運用ユーザー情報は含まない
+import bcrypt from "bcryptjs";
+import { getDb } from "./db.js";
+
+const SEED_ROUNDS = 4; // 教材用低コスト設定 (本番は 12 以上推奨)
+
+export interface SeedUser {
+  uuid: string;
+  username: string;
+  email: string;
+  password_hash: string;
+  role: "user" | "admin";
+}
+
+export function seedDatabase() {
+  const db = getDb();
+  db.exec("DELETE FROM victim_sessions; DELETE FROM victim_otp_used; DELETE FROM victim_orders; DELETE FROM victim_users;");
+
+  const users: Omit<SeedUser, "uuid">[] = [
+    { username: "seed_alice",       email: "alice@seed.example",   password_hash: bcrypt.hashSync("Passw0rd!", SEED_ROUNDS), role: "user" },
+    { username: "seed_bob",         email: "bob@seed.example",     password_hash: bcrypt.hashSync("hunter2",  SEED_ROUNDS), role: "user" },
+    { username: "seed_admin",       email: "admin@seed.example",   password_hash: bcrypt.hashSync("admin",    SEED_ROUNDS), role: "admin" },
+    { username: "attacker_charlie", email: "charlie@seed.example", password_hash: bcrypt.hashSync("attacker", SEED_ROUNDS), role: "user" },
+  ];
+
+  const stmt = db.prepare(
+    "INSERT INTO victim_users (username, email, password_hash, role) VALUES (?, ?, ?, ?)"
+  );
+  for (const u of users) {
+    stmt.run(u.username, u.email, u.password_hash, u.role);
+  }
+
+  // 各ユーザーに対応するサンプル注文データ (IDOR 攻撃のターゲット)
+  const aliceId = (db.prepare("SELECT id FROM victim_users WHERE username = ?").get("seed_alice") as any).id;
+  const bobId   = (db.prepare("SELECT id FROM victim_users WHERE username = ?").get("seed_bob")   as any).id;
+  const orderStmt = db.prepare("INSERT INTO victim_orders (user_id, item, amount) VALUES (?, ?, ?)");
+  orderStmt.run(aliceId, "OSI Layer Guide", 2980);
+  orderStmt.run(bobId,   "Security Handbook", 4980);
+}
+```
+
+### 5.3 DB 初期化フロー
+
+```
+コンテナ起動
+  └─ src/index.ts
+       └─ initDb()        # victim-data.sqlite を /app/data/ に作成 + DDL 実行
+            └─ seedDatabase()  # シードユーザー・注文データを投入
+
+POST /api/reset
+  └─ seedDatabase()       # 全テーブルを削除してシードを再投入
+```
+
+`victim-data.sqlite` は orchestrator の `server/db/data.sqlite` とは**物理的に別ファイル**であり、
+`POST /api/reset` (orchestrator 側) も `docker compose restart victim-web` (victim-web 側) も
+相手の DB に影響を与えない。
+
+---
+
+## 6. Dockerfile 方針
+
+```dockerfile
+FROM node:20-alpine
+LABEL org.opencontainers.image.description="教育用脆弱アプリ — victim-web (OSI Reference)"
+
+WORKDIR /app
+
+# npm workspaces を活用: root の package.json + lock + victim-web のみビルド
+COPY package.json package-lock.json ./
+COPY services/victim-web ./services/victim-web
+COPY shared ./shared
+
+RUN npm ci --workspace=@osi-ref/victim-web --include-workspace-root=false \
+    && npm run build --workspace=@osi-ref/victim-web \
+    && npm prune --omit=dev --workspace=@osi-ref/victim-web
+
+# 書き込み可能なデータディレクトリ (compose の tmpfs でマウント)
+RUN mkdir -p /app/data && chown node:node /app/data
+
+USER node
+EXPOSE 4001
+
+HEALTHCHECK --interval=10s --timeout=2s --retries=3 \
+    CMD wget -q -O- http://localhost:4001/health || exit 1
+
+CMD ["node", "services/victim-web/dist/index.js"]
+```
+
+### 6.1 compose 側の安全設定
+
+```yaml
+# docker-compose.yml (抜粋)
+services:
+  victim-web:
+    build:
+      context: .
+      dockerfile: services/victim-web/Dockerfile
+    networks:
+      - victim-net          # orchestrator からのみ到達可。external egress なし
+    ports: []               # ホスト側ポートは公開しない (victim-net 内部のみ)
+    environment:
+      - NODE_ENV=development
+      - PORT=4001
+    volumes:
+      - type: tmpfs
+        target: /app/data   # victim-data.sqlite を tmpfs に配置 (再起動でリセット)
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true         # tmpfs マウントを除きファイルシステム書き込み禁止
+    tmpfs:
+      - /tmp
+    mem_limit: 256m
+    pids_limit: 128
+
+networks:
+  victim-net:
+    driver: bridge
+    internal: true          # OS レイヤで egress を遮断
+```
+
+### 6.2 `--read-only` 対応
+
+victim-data.sqlite の書き込みは `volumes: - type: tmpfs target: /app/data` で対応する。
+コンテナ再起動時に tmpfs はクリアされるため、シードデータは起動時に毎回再投入される。
+永続化が必要な場合は `victim-db` named volume を使用する (compose のコメントで両案を提示)。
+
+---
+
+## 7. エラーハンドリング
+
+victim-web は意図的に脆弱だが、**教材として常時起動可能**であることを保証するため、
+クラッシュや信頼性問題は避ける。
+
+| エラー種別 | 対応方針 |
+|-----------|---------|
+| DB prepare 失敗・テーブル不在 | 500 + `{"error":"Internal error","detail":"<メッセージ>"}` で返す。`process.exit` しない |
+| リクエスト body parse 失敗 | 400 + `{"error":"Invalid request body"}` (zod は使わず、`JSON.parse` try-catch のみ) |
+| シード未投入状態での参照 | 503 + `{"error":"Seed not ready","hint":"POST /api/reset"}` |
+| /health エンドポイント | 常に 200 + `{"status":"ok","service":"victim-web"}` を返す |
+
+**最小バリデーション方針**: zod を依存に含めない。`typeof` / `in` 演算子による型ガードのみ使用する。
+これにより victim-web の依存を軽量に保ち、起動時間を短縮する。
+
+---
+
+## 8. テスト要件
+
+配置: `services/victim-web/__tests__/` (vitest)
+
+```typescript
+// services/victim-web/__tests__/jwt.test.ts の例
+import { describe, it, expect } from "vitest";
+
+describe("jwt-vuln: POST /jwt/verify", () => {
+  it("alg=none トークンを 200 で受理すること (CWE-345 概念実証)", async () => {
+    const algNoneToken = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWVkX2FsaWNlIiwicm9sZSI6ImFkbWluIn0.";
+    const res = await fetch("http://localhost:4001/jwt/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: algNoneToken }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.valid).toBe(true);
+    expect(body.claims.role).toBe("admin");
+  });
+});
+```
+
+### 8.1 必須テストケース一覧
+
+- [ ] `POST /jwt/verify` — alg=none トークンで 200 + `valid: true` が返ること
+- [ ] `POST /jwt/verify` — 署名ストリッピングトークンで 200 + `valid: true` が返ること
+- [ ] `POST /jwt/verify-kid` — `kid: "../../etc/hostname"` 等パストラバーサルパスでエラーなく応答すること
+- [ ] `POST /jwt/issue-weak` — 弱秘密鍵 (`"secret"`) で署名されたトークンが返ること
+- [ ] `GET /orders/1` — 認可ヘッダなしで 200 + 注文データが返ること
+- [ ] `GET /orders/2` — seed_alice のセッションで seed_bob の注文が取得できること
+- [ ] `POST /session/login` — body の `sid` が Set-Cookie にそのまま使われること
+- [ ] `GET /session/me` — Cookie ヘッダに `HttpOnly` 属性が**ない**こと
+- [ ] `POST /token/refresh` — 同一 jti で 2 回とも 200 が返ること
+- [ ] `GET /oauth/authorize` — `state` なしで認可コードが発行されること
+- [ ] `POST /oauth/redirect` — `http://localhost:3000.evil.example/` が通ること
+- [ ] `POST /oidc/verify-id-token` — `aud` / `iss` が不正でも 200 が返ること
+- [ ] `POST /saml/consume-assertion` — 期限切れアサーションを 2 回とも受理すること
+- [ ] `POST /mfa/verify` — 同一 OTP を 2 回送信して両方 200 が返ること
+- [ ] `GET /api/resource?api_key=...` — クエリパラメータのキーで 200 が返ること
+- [ ] `POST /api/hmac` — `X-Signature` ヘッダなしで 200 が返ること
+- [ ] `POST /api/replay` — 同一タイムスタンプで 2 回とも 200 が返ること
+- [ ] `POST /api/reset` — シードデータが再構築されること (ユーザー数 4 件)
+- [ ] `GET /health` — 常に 200 + `{"status":"ok"}` が返ること
+- [ ] `victim-data.sqlite` と `server/db/data.sqlite` が別プロセスから独立していること
+
+---
+
+## 9. 既存 `server/routes/*.ts` との対応関係
+
+| 攻撃シナリオ ID | victim-web エンドポイント (脆弱) | 堅牢実装 (orchestrator 既存) | 脆弱性の核心 |
+|---------------|-------------------------------|---------------------------|-------------|
+| jwt-alg-none | `POST /jwt/verify` | `server/routes/jwt-ops.ts` `POST /api/jwt/verify` | `algorithms` 未指定 |
+| jwt-signature-stripping | `POST /jwt/verify` | 同上 | `algorithms` 未指定 |
+| jwt-kid-injection | `POST /jwt/verify-kid` | `server/routes/jwt-ops.ts` (kid allowlist) | kid をパスとして使用 |
+| jwt-weak-secret-bruteforce | `POST /jwt/issue-weak` | `server/routes/jwt-ops.ts` `POST /api/jwt/sign` | 弱秘密鍵 `"secret"` |
+| rbac-idor | `GET /orders/:id` | `server/routes/rbac.ts` `POST /api/rbac/check` | 認可チェックなし |
+| rbac-horizontal-privesc | `GET /users/:id` | `server/routes/rbac.ts` | 所有者確認なし |
+| rbac-vertical-privesc | `POST /admin/:action` | `server/routes/rbac.ts` | role クレームを DB 照合せず信用 |
+| rbac-abac-tampering | `POST /resource` | `server/routes/rbac.ts` (ABAC ルール) | X-Department ヘッダを無条件信頼 |
+| session-fixation | `POST /session/login` | `server/routes/session-auth.ts` `POST /api/session/login` | 認証後セッション ID 再生成なし |
+| session-xss-cookie-steal | `GET /session/me` | `server/routes/session-auth.ts` | HttpOnly 属性なし |
+| session-token-replay | `POST /token/refresh` | `server/routes/token-auth.ts` `/refresh` | jti 重複検出なし |
+| oauth-state-csrf | `GET /oauth/authorize` | `server/routes/oauth-sim.ts` `GET /api/oauth/authorize` | state パラメータ必須化なし |
+| oauth-redirect-uri-bypass | `POST /oauth/redirect` | `server/routes/oauth-sim.ts` (allowlist 完全一致) | startsWith 部分一致検証 |
+| oidc-id-token-spoofing | `POST /oidc/verify-id-token` | `server/routes/oidc-saml-sim.ts` | aud/iss 検証なし |
+| saml-assertion-replay | `POST /saml/consume-assertion` | `server/routes/oidc-saml-sim.ts` | NotOnOrAfter / InResponseTo 無検証 |
+| mfa-otp-replay | `POST /mfa/verify` | `server/routes/mfa-totp.ts` `POST /api/mfa/totp/*` | 使用済み OTP フラグなし |
+| sso-apikey-leakage | `GET /api/resource` | `server/routes/sso-apikey.ts` | URL クエリパラメータでキーを受理 |
+| sso-hmac-bypass | `POST /api/hmac` | `server/routes/sso-apikey.ts` (HMAC-SHA256) | X-Signature 未検証で通過 |
+| sso-replay-no-timestamp | `POST /api/replay` | `server/routes/sso-apikey.ts` (replay_nonce) | タイムスタンプ・nonce 検証なし |
+
+この対応表は `AttackDefensePanel` の「防御策コードへのリンク」として参照される。
+
+---
+
+## 10. 将来拡張
+
+### 10.1 Phase 4 コンテナ (本仕様のスコープ外)
+
+| コンテナ | 対応 B 群シナリオ | 仕様書 |
+|---------|----------------|-------|
+| `services/victim-tls-proxy/` (nginx + 旧 openssl) | tls-version-downgrade, tls-self-signed-mitm, tls-weak-cipher | DESIGN/35 (予定) |
+| `services/victim-saml-idp/` (python + xmlsec1 または Hono) | saml-xsw, pass-the-ticket | DESIGN/36 (予定) |
+
+これらは `victim-net` に追加接続するだけで orchestrator の `VICTIM_ALLOWLIST` に新エントリを追加すれば到達可能になる設計とする。
+
+### 10.2 Phase 5 整理方針
+
+C 群 11 件 + D 群 4 件は victim-web に対応エンドポイントを追加しない。
+これらは既存 `server/routes/*.ts` の `/attack/*` パスで引き続きナレーション型として提供し、
+Phase 5 で `SIMULATION` / `DEFENSE DEMO` バッジを付与して UI 整理を行う。
+
+### 10.3 A 群 bruteforce-noratelimit の扱い
+
+シナリオ #3 (`auth-methods/bruteforce-noratelimit`) は `POST /login` (rate limit なし) を victim-web に追加することで対応する。
+attacker-shell (`--pids-limit=64`) からの辞書ループ (上限 20 回) を orchestrator が中継する形を取り、
+フロントエンドで実際のループを実行することはない (DESIGN/04 §1.3 簡略化原則)。
+本エンドポイントは Phase 2 の PoC 5 件には含まれず、Phase 3 バンドル PR で追加する。
+
+---
+
+## 11. ソースファイル冒頭コメント規約
+
+`services/victim-web/src/routes/*.ts` の先頭には以下のブロックを必ず含める。
+
+```typescript
+/**
+ * 脆弱エンドポイント: <エリア名>
+ *
+ * 【教育目的専用】
+ * このファイルは OSI 参照アプリの教材機能として、
+ * victim-net 内の固定シードデータに対する概念実証を提供します。
+ *
+ * - 外部ネットワークへのリクエストは行いません
+ * - 実 CVE のエクスプロイトコードは含みません
+ * - victim-net 外での動作は想定していません
+ *
+ * 対応 CWE: CWE-xxx, CWE-yyy
+ * 堅牢実装: server/routes/<area>.ts
+ * 関連設計書: DESIGN/04-safety-guardrails.md, DESIGN/32-victim-web-spec.md
+ */
+```
+
+---
+
+## 関連ファイル
+
+### 上流設計
+
+| ファイル | 関係 |
+|---------|-----|
+| `DESIGN/30-live-attack-architecture.md` | 全体アーキテクチャ・シナリオ分類表 (A/B/C/D)・Phase ロードマップ |
+| `DESIGN/04-safety-guardrails.md` | 4 原則 (隔離・明示・簡略化・防御策併記)、禁止表現一覧 §2.3、シードユーザー規約 §5.1 |
+
+### 同列設計
+
+| ファイル | 関係 |
+|---------|-----|
+| `DESIGN/31-orchestrator-spec.md` | `POST /api/orchestrator/exec` — 本仕様の victim-web を `target` として呼び出す側 |
+| `DESIGN/33-raw-http-composer.md` | RawHttpComposer フロント UI — 学習者が攻撃リクエストを組み立てる入口 |
+| `DESIGN/34-safety-guardrails-live.md` | live 化安全装置の詳細 (`VICTIM_ALLOWLIST`, `internal: true` 等) |
+
+### 堅牢実装 (防御側の対比対象)
+
+| ファイル | 対応する攻撃エリア |
+|---------|----------------|
+| `server/routes/jwt-ops.ts` | JWT 系 3 シナリオ |
+| `server/routes/rbac.ts` | RBAC 系 4 シナリオ |
+| `server/routes/session-auth.ts` | Session 系 (fixation, xss-cookie) |
+| `server/routes/token-auth.ts` | Session 系 (token-replay) |
+| `server/routes/oauth-sim.ts` | OAuth 系 2 シナリオ |
+| `server/routes/oidc-saml-sim.ts` | OIDC/SAML 系 2 シナリオ |
+| `server/routes/mfa-totp.ts` | MFA 系 1 シナリオ |
+| `server/routes/sso-apikey.ts` | SSO/APIKey 系 3 シナリオ |
+
+### シード規約
+
+| ファイル | 関係 |
+|---------|-----|
+| `DESIGN/04-safety-guardrails.md` §5 | シードユーザー定義・リセット仕様の基準 |
+| `server/db/schema.ts` `seedDb()` | orchestrator 側の実装参考 (同じ seed_alice / seed_bob 規約を踏襲) |

--- a/DESIGN/33-raw-http-composer.md
+++ b/DESIGN/33-raw-http-composer.md
@@ -1,0 +1,977 @@
+---
+title: 攻撃デモカタログ — RawHttpComposer / SequenceDiagram UI 仕様
+phase: design
+audience: フロントエンド開発者・UI レビュアー
+last-updated: 2026-05-02
+safety-reviewed: false
+---
+
+# 33. RawHttpComposer / SequenceDiagram UI 仕様
+
+## 1. 目的とスコープ
+
+### 1.1 概要
+
+本仕様は `AttackPanel` を `mode: "live"` シナリオ向けに拡張するための新規 2 コンポーネントと、
+既存コンポーネントへの変更点を定義する。
+学習者が生 HTTP リクエストを自ら編集し、Docker 隔離された victim コンテナと実通信することで、
+「攻撃者がどのリクエストを組み立てるか」を体感できる UI を提供する。
+
+教育目的の範囲内に留まるため、DESIGN/04 の 4 原則 (隔離・明示・簡略化・防御策併記) は
+ナレーション型と同等以上の強度で維持する。
+
+### 1.2 新規コンポーネント
+
+| コンポーネント | ファイルパス | 役割 |
+|---|---|---|
+| `RawHttpComposer` | `src/components/shared/RawHttpComposer.tsx` | 生 HTTP リクエスト編集 UI。target・method・path・headers・body を組み立てて orchestrator に送信 |
+| `SequenceDiagramView` | `src/components/shared/SequenceDiagramView.tsx` | Browser / Orchestrator / Victim の 3 アクター間シーケンス図を D3 SVG で描画 |
+
+### 1.3 既存コンポーネントとの統合方針
+
+- `EducationalWarningBanner`: `mode: "live"` 選択時に右端へ `LIVE` バッジを追加 (子要素追加のみ)
+- `AttackScenarioSelector`: 各シナリオ名右側に `[LIVE]` / `[NARRATION]` バッジを追加
+- `AttackPanel`: `meta.mode` を読んで `RawHttpComposer` / 既存実行ボタン を排他表示
+- `DataFlowPanel`: 4 番目のタブ "Sequence" を追加し `SequenceDiagramView` を内包
+- `AttackStepTimeline`: `mode: "live"` では orchestrator レスポンスの `rawExchange` から steps を生成
+- `AttackResultBanner` / `AttackDefensePanel`: 変更なし (両モード共通)
+
+---
+
+## 2. `RawHttpComposer` コンポーネント
+
+### 2.1 配置
+
+- ファイル: `src/components/shared/RawHttpComposer.tsx`
+- CSS: `src/components/shared/RawHttpComposer.css`
+- `AttackPanel` 内: `AttackScenarioSelector` の直下、既存実行ボタンの代替として配置
+- `<Show when={props.meta?.mode === "live"}>` で囲み、`mode !== "live"` のときは非表示
+
+### 2.2 視覚レイアウト (ASCII)
+
+```
+┌─ RawHttpComposer ─────────────────────────────────────────────────────┐
+│  Target: [victim-web ▼]                           [LIVE]              │
+│                                                                        │
+│  ┌──────────────────────────────────────────────────────────────────┐  │
+│  │  Method: [POST ▼]   Path: [/jwt/verify                       ]  │  │
+│  ├──────────────────────────────────────────────────────────────────┤  │
+│  │  [Headers]  [Body]  [Raw]        ← タブ                          │  │
+│  │                                                                   │  │
+│  │  ┌── Headers タブ ──────────────────────────────────────────┐   │  │
+│  │  │  Host:          [victim-web:4001 (orchestrator が設定)]  │   │  │
+│  │  │                  ← disabled / opacity: 0.6               │   │  │
+│  │  │  Content-Type:  [application/json                    ] [×] │  │
+│  │  │  [+ ヘッダを追加]                                         │   │  │
+│  │  └──────────────────────────────────────────────────────────┘   │  │
+│  │  (jwt-alg-none: token は Body タブの JSON body 内に配置。         │  │
+│  │   Authorization ヘッダではなく {"token": "<偽造 JWT>"} を送信)  │  │
+│  └──────────────────────────────────────────────────────────────────┘  │
+│                                                                        │
+│  [SEND ATTACK]                         ← background: --color-attack-accent │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+**Body タブ:**
+```
+│  ┌── Body タブ ─────────────────────────────────────────────────┐   │  │
+│  │  <textarea rows="6" spellcheck="false" font-family: mono>   │   │  │
+│  │  {                                                           │   │  │
+│  │    "token": "eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWVkX2FsaWNlIn0."  │   │  │
+│  │  }  ← jwt-alg-none: alg=none + 空署名の偽造 JWT を body で送信   │   │  │
+│  └──────────────────────────────────────────────────────────────┘   │  │
+```
+
+**Raw タブ (編集不可):**
+```
+│  ┌── Raw タブ ──────────────────────────────────────────────────┐   │  │
+│  │  POST /jwt/verify HTTP/1.1                                   │   │  │
+│  │  Host: victim-web:4001                                       │   │  │
+│  │  Content-Type: application/json                              │   │  │
+│  │                                                              │   │  │
+│  │  {"token":"eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWVkX2FsaWNlIn0."}  │   │  │
+│  │                            ← readonly, cursor: default       │   │  │
+│  └──────────────────────────────────────────────────────────────┘   │  │
+```
+
+### 2.3 Props および内部 State
+
+```typescript
+// shared/api-types.ts からの再利用型
+import type { OrchestratorExecRequest, OrchestratorExecResponse, VictimTarget } from "../../../shared/api-types";
+
+type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+interface RawHttpComposerProps {
+  scenarioId: string;
+  /** VICTIM_ALLOWLIST 由来のターゲット一覧 (orchestrator から取得済み) (`VictimTarget` は string リテラル union — DESIGN/31 §5.1) */
+  allowedTargets: VictimTarget[];
+  /** シナリオ固有の初期値テンプレート。未指定なら空リクエスト */
+  templateRequest?: {
+    method: HttpMethod;
+    path: string;
+    headers: Record<string, string>;
+    body?: string;
+  };
+  /** 送信コールバック。AttackPanel の handleRunAttack から呼ばれる */
+  onSend: (
+    request: OrchestratorExecRequest["request"]
+  ) => Promise<OrchestratorExecResponse>;
+}
+```
+
+**内部 Signal 一覧:**
+
+```typescript
+// RawHttpComposer 内部 (コンポーネント本体)
+const [target, setTarget] = createSignal<string>(
+  props.allowedTargets[0] ?? "victim-web"
+);
+const [method, setMethod] = createSignal<HttpMethod>(
+  props.templateRequest?.method ?? "GET"
+);
+const [path, setPath] = createSignal<string>(
+  props.templateRequest?.path ?? "/"
+);
+// key-value ペアの配列 (Host は含まない — orchestrator が上書き)
+const [headers, setHeaders] = createSignal<{ key: string; value: string }[]>(
+  Object.entries(props.templateRequest?.headers ?? {})
+    .filter(([k]) => k.toLowerCase() !== "host")
+    .map(([key, value]) => ({ key, value }))
+);
+const [body, setBody] = createSignal<string>(
+  props.templateRequest?.body ?? ""
+);
+const [activeTab, setActiveTab] = createSignal<"headers" | "body" | "raw">(
+  "headers"
+);
+const [sending, setSending] = createSignal(false);
+```
+
+**rawText 派生値 (Raw タブ用):**
+
+```typescript
+const rawText = () => {
+  const reqHeaders = [
+    `Host: victim-web:4001`,   // orchestrator 決定値を表示
+    ...headers().map((h) => `${h.key}: ${h.value}`),
+  ].join("\r\n");
+  const bodyStr = body().trim();
+  return [
+    `${method()} ${path()} HTTP/1.1`,
+    reqHeaders,
+    "",
+    bodyStr,
+  ].join("\r\n");
+};
+```
+
+### 2.4 安全制約 (DESIGN/04 §1.1 強化)
+
+| 制約 | 実装方法 |
+|---|---|
+| **target は dropdown 選択のみ** | `<select>` に `props.allowedTargets` を `<For>` で列挙。自由入力フィールドなし |
+| **Host ヘッダ編集不可** | `<input disabled>` + `opacity: 0.6` + `cursor: not-allowed`。テキスト: `orchestrator が victim-web:4001 に設定` |
+| **export / copy / download ボタンなし** | Raw タブは `<textarea readonly>` の表示のみ。クリップボード API 呼び出し禁止 |
+| **localStorage / sessionStorage 書き込みなし** | 全状態は Signal のみ。ページリロードで `templateRequest` に戻る |
+| **`console.log` 出力なし** | DESIGN/04 §7.1 準拠。全可視化は DataFlowPanel 経由 |
+
+### 2.5 視覚デザイン (PCB テーマ準拠)
+
+```css
+/* RawHttpComposer.css */
+
+.raw-http-composer {
+  border: 1px solid var(--color-attack-accent);   /* 赤縁: 攻撃モード明示 */
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  padding: 1rem;
+  position: relative;
+}
+
+/* 右上 LIVE バッジ */
+.raw-http-composer-live-badge {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  background: var(--color-attack-bg);
+  color: var(--color-attack-accent);
+  border: 1px solid var(--color-attack-accent);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 2px 6px;
+  letter-spacing: 0.05em;
+}
+
+/* Target + Method + Path 行 */
+.raw-http-composer-topbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+
+.raw-http-composer-topbar select,
+.raw-http-composer-topbar input {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 3px 6px;
+}
+
+/* 内部タブ */
+.raw-http-composer-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: 0.5rem;
+}
+
+.raw-http-composer-tab {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  padding: 4px 10px;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+
+.raw-http-composer-tab[data-active="true"] {
+  color: var(--color-attack-accent);
+  border-bottom-color: var(--color-attack-accent);
+}
+
+/* 編集不可フィールド */
+.raw-http-composer-disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* SEND ボタン */
+.raw-http-composer-send {
+  margin-top: 0.75rem;
+  background: var(--color-attack-accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 6px 16px;
+  cursor: pointer;
+  transition: transform var(--transition-fast);
+}
+
+.raw-http-composer-send:hover:not(:disabled) {
+  transform: scale(1.02);
+}
+
+.raw-http-composer-send:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+```
+
+### 2.6 a11y
+
+```typescript
+// RawHttpComposer.tsx の JSX 抜粋 (Solid.js 必須ルール準拠)
+
+// target dropdown
+<label for="rhc-target">{t("送信先", "Target")}</label>
+<select
+  id="rhc-target"
+  value={target()}
+  onChange={(e) => setTarget(e.currentTarget.value)}
+  aria-label={t("攻撃対象の victim を選択", "Select attack target")}
+>
+  <For each={props.allowedTargets}>
+    {(tgt) => <option value={tgt}>{tgt}</option>}
+  </For>
+</select>
+
+// target 変更時の aria-live アナウンス
+<div aria-live="polite" class="sr-only">
+  <Show when={target()}>
+    {t(
+      `送信先が ${target()} に変更されました`,
+      `Target changed to ${target()}`
+    )}
+  </Show>
+</div>
+
+// SEND ボタン
+<button
+  class="raw-http-composer-send"
+  disabled={sending() || props.allowedTargets.length === 0}
+  aria-busy={sending()}
+  aria-describedby="rhc-send-desc"
+  onClick={handleSend}
+>
+  <Show when={sending()} fallback={t("送信", "Send Attack")}>
+    {t("送信中...", "Sending...")}
+  </Show>
+</button>
+<span id="rhc-send-desc" class="sr-only">
+  {t(
+    "実際の HTTP リクエストを victim コンテナに送信します",
+    "Sends a real HTTP request to the victim container"
+  )}
+</span>
+
+// Host ヘッダ (disabled)
+<label for="rhc-host-header">{t("Host ヘッダ", "Host header")}</label>
+<input
+  id="rhc-host-header"
+  class="raw-http-composer-disabled"
+  disabled
+  value={t("victim-web:4001 (orchestrator が設定)", "victim-web:4001 (set by orchestrator)")}
+  aria-label={t("Host ヘッダは orchestrator が強制設定します", "Host header is overridden by orchestrator")}
+/>
+```
+
+フォーカスリングは `app.css` の `:focus-visible` ルール (既存) が自動適用される。
+
+### 2.7 i18n 文言一覧
+
+| 概念 | 日本語 | English |
+|---|---|---|
+| 送信先ラベル | `送信先` | `Target` |
+| メソッドラベル | `メソッド` | `Method` |
+| パスラベル | `パス` | `Path` |
+| ヘッダタブ | `ヘッダー` | `Headers` |
+| ボディタブ | `ボディ` | `Body` |
+| Raw タブ | `Raw` | `Raw` |
+| ヘッダ追加ボタン | `+ ヘッダを追加` | `+ Add header` |
+| ヘッダ削除 | `削除` | `Remove` |
+| 送信ボタン | `送信` | `Send Attack` |
+| 送信中 | `送信中...` | `Sending...` |
+| LIVE バッジ | `LIVE 攻撃モード` | `LIVE attack mode` |
+| Host 無効説明 | `orchestrator が victim-web:4001 に設定` | `set by orchestrator` |
+| target 変更告知 | `送信先が ${x} に変更されました` | `Target changed to ${x}` |
+
+---
+
+## 3. `SequenceDiagramView` コンポーネント
+
+### 3.1 配置
+
+- ファイル: `src/components/shared/SequenceDiagramView.tsx`
+- CSS: `src/components/shared/SequenceDiagramView.css`
+- `DataFlowPanel` 内の 4 番目のタブ `"Sequence"` に格納
+- タブ一覧: `HTTP` / `Trace` / `DB` / `Sequence`
+- `mode: "live"` のときのみ Sequence タブを表示 (`<Show when={isLiveMode()}>`)
+
+### 3.2 描画方針
+
+D3 ベースの自前 SVG を採用する (Mermaid は bundle 増加・テーマ統一性の問題がある)。
+CLAUDE.md の「D3 + Solid 統合パターン」を厳守する。
+
+```typescript
+// SequenceDiagramView.tsx の骨格
+import { onMount, onCleanup, createEffect } from "solid-js";
+import * as d3 from "d3";
+
+function SequenceDiagramView(props: SequenceDiagramViewProps) {
+  let svgRef: SVGSVGElement | undefined;
+
+  // D3 初期化は onMount のみ (コンポーネント関数は 1 回だけ実行)
+  onMount(() => {
+    const svg = d3.select(svgRef!);
+    initDiagram(svg);
+  });
+
+  // exchange 変更を監視して D3 transition をトリガー
+  createEffect(() => {
+    const ex = props.exchange;
+    if (!svgRef || !ex) return;
+    const svg = d3.select(svgRef!);
+    updateArrows(svg, ex);  // 400ms transition
+  });
+
+  // トランジションキャンセル (コンポーネント破棄時)
+  onCleanup(() => {
+    if (svgRef) {
+      d3.select(svgRef!).selectAll("*").interrupt();
+    }
+  });
+
+  return (
+    <div class="sequence-diagram-view">
+      <svg ref={svgRef} class="sequence-diagram-svg" aria-label={/* ... */} />
+      {/* popup は Solid で管理: D3 が管理する SVG 内部に Solid は介入しない */}
+      <Show when={popupArrow() !== null}>
+        <RawBytesPopup arrow={popupArrow()!} onClose={() => setPopupArrow(null)} />
+      </Show>
+    </div>
+  );
+}
+```
+
+D3 が管理する SVG 内部には Solid の JSX を挿入しない。
+クリック popup は SVG 外の `<Show>` コンポーネントで管理する。
+
+### 3.3 視覚レイアウト (ASCII)
+
+3 アクター (Browser, Orchestrator, Victim) のスイムレーン:
+
+```
+  Browser              Orchestrator              Victim (victim-web)
+    │                      │                          │
+    │                      │                          │
+  ──●──────────────────────●──────────────────────────●──   ← ライフライン
+    │                      │                          │
+    │── POST /api/exec ───▶│                          │       (→ 400ms)
+    │                      │── POST /jwt/verify ─────▶│       (→ 400ms)
+    │                      │                          │ [脆弱: alg=none 受理]
+    │                      │◀── 200 OK ───────────────│       (← 400ms, 青)
+    │◀── AttackResult ─────│                          │       (← 400ms, 青)
+    │                      │                          │
+    [矢印クリック] → RawBytesPopup (request/response raw bytes)
+```
+
+**凡例:**
+
+| 表示 | 意味 |
+|---|---|
+| 橙色矢印 (→) | リクエスト方向 (Browser→Orchestrator, Orchestrator→Victim) |
+| 青色矢印 (←) | レスポンス方向 |
+| `[脆弱: ...]` ラベル | victim 応答の横注釈 (成功時は橙、ブロック時は緑) |
+| クリック可能矢印 | `cursor: pointer`, hover で `stroke-width` を 3 に変化 |
+
+### 3.4 Props
+
+```typescript
+interface RawArrow {
+  from: "browser" | "orchestrator" | "victim";
+  to: "browser" | "orchestrator" | "victim";
+  label: string;         // "POST /jwt/verify HTTP/1.1" など
+  direction: "request" | "response";
+  rawBytes: string;      // クリック popup で表示する生テキスト
+  elapsedMs?: number;
+}
+
+interface SequenceDiagramViewProps {
+  /** orchestrator レスポンスの rawExchange をそのまま渡す */
+  exchange: OrchestratorExecResponse["rawExchange"];
+  scenarioId: string;
+}
+```
+
+内部で `exchange` から `RawArrow[]` を派生させ、D3 に渡す:
+
+```typescript
+/**
+ * RawExchange の階層構造からシーケンス図用の平坦なフィールドを導出するヘルパー。
+ * RawExchange 構造: { browserToOrchestrator: { request, response }, orchestratorToVictim: { request, response, targetResolvedTo }, elapsedMs }
+ */
+function deriveArrows(ex: RawExchange): RawArrow[] {
+  const b2o = ex.browserToOrchestrator;
+  const o2v = ex.orchestratorToVictim;
+
+  // orchestrator→victim リクエスト行から method と path を分割
+  // 例: "POST /jwt/verify HTTP/1.1" → method="POST", path="/jwt/verify"
+  const [victimMethod, victimPath] = o2v.request.line.split(" ");
+
+  return [
+    {
+      from: "browser",
+      to: "orchestrator",
+      label: "POST /api/orchestrator/exec",
+      direction: "request",
+      rawBytes: [
+        b2o.request.line,
+        ...Object.entries(b2o.request.headers).map(([k, v]) => `${k}: ${v}`),
+        "",
+        b2o.request.body ?? "",
+      ].join("\r\n"),
+    },
+    {
+      from: "orchestrator",
+      to: "victim",
+      label: `${victimMethod} ${victimPath} HTTP/1.1`,
+      direction: "request",
+      rawBytes: [
+        o2v.request.line,
+        ...Object.entries(o2v.request.headers).map(([k, v]) => `${k}: ${v}`),
+        "",
+        o2v.request.body ?? "",
+      ].join("\r\n"),
+      elapsedMs: ex.elapsedMs,
+    },
+    {
+      from: "victim",
+      to: "orchestrator",
+      label: o2v.response.line,
+      direction: "response",
+      rawBytes: [
+        o2v.response.line,
+        ...Object.entries(o2v.response.headers).map(([k, v]) => `${k}: ${v}`),
+        "",
+        o2v.response.body ?? "",
+      ].join("\r\n"),
+    },
+    {
+      from: "orchestrator",
+      to: "browser",
+      label: "AttackResult",
+      direction: "response",
+      rawBytes: [
+        b2o.response.line,
+        ...Object.entries(b2o.response.headers).map(([k, v]) => `${k}: ${v}`),
+        "",
+        b2o.response.body ?? "",
+      ].join("\r\n"),
+    },
+  ];
+}
+
+const arrows = (): RawArrow[] => {
+  const ex = props.exchange;
+  if (!ex) return [];
+  return deriveArrows(ex);
+};
+```
+
+### 3.5 RawBytesPopup
+
+矢印クリックで表示するモーダル (Solid JSX で管理):
+
+```typescript
+// SVG 外に配置
+function RawBytesPopup(props: { arrow: RawArrow; onClose: () => void }) {
+  const { t } = useI18n();
+  return (
+    <div
+      class="raw-bytes-popup"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("生バイト表示", "Raw bytes")}
+    >
+      <div class="raw-bytes-popup-header">
+        <span class="raw-bytes-popup-title">{props.arrow.label}</span>
+        <button
+          class="raw-bytes-popup-close"
+          aria-label={t("閉じる", "Close")}
+          onClick={props.onClose}
+        >
+          [×]
+        </button>
+      </div>
+      <pre class="raw-bytes-popup-body mono">{props.arrow.rawBytes}</pre>
+    </div>
+  );
+}
+```
+
+### 3.6 アニメーション
+
+```typescript
+// D3 transition (solid-motionone は使わない)
+function drawArrow(
+  svg: d3.Selection<SVGSVGElement, unknown, null, undefined>,
+  arrow: RawArrow,
+  index: number,
+  xMap: Record<string, number>,
+  yBase: number
+) {
+  const y = yBase + index * 60;
+  const fromX = xMap[arrow.from];
+  const toX = xMap[arrow.to];
+  const color = arrow.direction === "request" ? "var(--color-attack-accent)" : "#1677ff";
+
+  const line = svg.append("line")
+    .attr("class", "seq-arrow")
+    .attr("x1", fromX)
+    .attr("y1", y)
+    .attr("x2", fromX)  // 初期値: 折れ点なし
+    .attr("y2", y)
+    .attr("stroke", color)
+    .attr("stroke-width", 2)
+    .attr("marker-end", `url(#arrow-${arrow.direction})`);
+
+  // 400ms で fromX → toX
+  line.transition()
+    .duration(400)
+    .ease(d3.easeLinear)
+    .attr("x2", toX);
+}
+
+// onCleanup でキャンセル
+onCleanup(() => {
+  d3.select(svgRef!).selectAll("*").interrupt();
+});
+```
+
+---
+
+## 4. 既存 `AttackPanel` への統合
+
+### 4.1 変更点
+
+`AttackPanel.tsx` に `mode` 判定を追加する。シナリオの `meta.mode` を参照して
+`RawHttpComposer` / 既存実行ボタンを排他表示に切り替える。
+
+```typescript
+// AttackPanel.tsx への追加
+const isLiveMode = () => selectedScenario()?.mode === "live";
+
+async function handleLiveSend(
+  request: OrchestratorExecRequest["request"]
+): Promise<OrchestratorExecResponse> {
+  setSending(true);
+  setAttackResult(null);
+  setDefenseOpen(false);
+  try {
+    const res = await apiPost<OrchestratorExecResponse>(
+      "/api/orchestrator/exec",
+      { scenarioId: selectedId(), target: target(), request },
+      `attack-${props.tabId}`
+    );
+    setAttackResult(res);
+    setRawExchange(res.rawExchange ?? null);  // SequenceDiagramView へ伝播
+    return res;
+  } finally {
+    setSending(false);
+  }
+}
+
+// `AttackPanel` は `target: Signal<VictimTarget>` を保持し、`RawHttpComposer` の dropdown 変更時に更新する
+```
+
+追加 Signal:
+
+```typescript
+const [rawExchange, setRawExchange] =
+  createSignal<OrchestratorExecResponse["rawExchange"] | null>(null);
+```
+
+### 4.2 統合後のレイアウト構造
+
+```
+AttackPanel
+├── EducationalWarningBanner           (常時表示 + live 時は LIVE バッジ付与)
+├── AttackScenarioSelector             (常時表示 + 各シナリオに [LIVE]/[NARRATION] バッジ)
+├── <Show when={isLiveMode()}>
+│     RawHttpComposer                  ← NEW (live モードのみ)
+│     onSend={handleLiveSend}
+│   </Show>
+├── <Show when={!isLiveMode()}>
+│     <div class="attack-mode-labels"> (既存 mode ラベル)
+│     <button class="attack-run-button"> (既存実行ボタン)
+│   </Show>
+├── AttackStepTimeline                 (両モード共通)
+├── AttackResultBanner                 (両モード共通)
+├── AttackDefensePanel                 (両モード共通、攻撃完了後自動展開)
+└── DataFlowPanel                      (scopeId="attack-{tabId}")
+    ├── HTTP タブ
+    ├── Trace タブ
+    ├── DB タブ
+    └── <Show when={isLiveMode()}>
+          Sequence タブ (SequenceDiagramView)
+        </Show>
+```
+
+### 4.3 DataFlowPanel の Sequence タブ追加
+
+`DataFlowPanel.tsx` の `tab` Signal に `"sequence"` を追加する:
+
+```typescript
+// DataFlowPanel.tsx 変更箇所
+const [tab, setTab] = createSignal<"http" | "trace" | "db" | "sequence">("http");
+
+// タブボタン追加
+<Show when={props.isLiveMode}>
+  <button
+    class="data-flow-tab"
+    role="tab"
+    aria-selected={tab() === "sequence"}
+    data-active={tab() === "sequence"}
+    onClick={() => setTab("sequence")}
+  >
+    {t("シーケンス", "Sequence")}
+  </button>
+</Show>
+
+// tabpanel 追加
+<Show when={tab() === "sequence" && props.isLiveMode}>
+  <SequenceDiagramView
+    exchange={props.rawExchange}
+    scenarioId={props.scopeId}
+  />
+</Show>
+```
+
+`DataFlowPanel` に追加される Props:
+
+```typescript
+interface DataFlowPanelProps {
+  scopeId: string;
+  defaultOpen?: boolean;
+  // live モード拡張 (未指定時は false / undefined で既存挙動を維持)
+  isLiveMode?: boolean;
+  rawExchange?: OrchestratorExecResponse["rawExchange"] | null;
+}
+```
+
+---
+
+## 5. `mode: "live"` バッジ表示
+
+### 5.1 EducationalWarningBanner への追加
+
+`EducationalWarningBanner` に `mode` prop を追加し、`mode === "live"` 時に右端バッジを表示する。
+
+```typescript
+// EducationalWarningBanner.tsx 変更
+interface EducationalWarningBannerProps {
+  mode?: "live" | "narration";
+}
+
+function EducationalWarningBanner(props: EducationalWarningBannerProps) {
+  const { t } = useI18n();
+  return (
+    <div class="edu-warning-banner" role="note" aria-live="polite"
+      aria-label={t("教育用シミュレーション警告", "Educational simulation warning")}
+    >
+      <span class="edu-warning-icon" aria-hidden="true">⚠</span>
+      <span class="edu-warning-text">
+        {t(
+          "教育用シミュレーション — 実環境を攻撃するためのコードではありません",
+          "Educational simulation — not for use against real systems"
+        )}
+      </span>
+      <Show when={props.mode === "live"}>
+        <span
+          class="edu-warning-live-badge"
+          aria-label={t("LIVE 攻撃モード", "LIVE attack mode")}
+        >
+          LIVE
+        </span>
+      </Show>
+    </div>
+  );
+}
+```
+
+**LIVE バッジ CSS:**
+
+```css
+.edu-warning-live-badge {
+  margin-left: auto;
+  background: var(--color-attack-bg);
+  color: var(--color-attack-accent);
+  border: 2px solid var(--color-attack-accent);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 2px 8px;
+  letter-spacing: 0.1em;
+  flex-shrink: 0;
+}
+```
+
+### 5.2 AttackScenarioSelector へのモードバッジ
+
+各シナリオチップ右側に `[LIVE]` / `[NARRATION]` バッジを追加する:
+
+```typescript
+// AttackScenarioSelector.tsx のチップ JSX 内
+<Show when={scenario.mode === "live"}>
+  <span class="scenario-mode-badge" data-mode="live">LIVE</span>
+</Show>
+<Show when={scenario.mode === "narration"}>
+  <span class="scenario-mode-badge" data-mode="narration">NARRATION</span>
+</Show>
+```
+
+```css
+.scenario-mode-badge[data-mode="live"] {
+  background: var(--color-attack-bg);
+  color: var(--color-attack-accent);
+  border: 1px solid var(--color-attack-accent);
+}
+
+.scenario-mode-badge[data-mode="narration"] {
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  border: 1px solid var(--border-subtle);
+}
+```
+
+---
+
+## 6. エラーハンドリング
+
+### 6.1 orchestrator からのエラー応答
+
+| HTTP ステータス | 原因 | UI 表示 |
+|---|---|---|
+| `502 Bad Gateway` | victim-web 未起動 | トースト: `t("victim-web が起動していません。docker compose up -d victim-web を実行してください", "victim-web is not running. Run: docker compose up -d victim-web")` + 「防御者モードに戻る」ボタン |
+| `503 Service Unavailable` | `NODE_ENV === "production"` または Phase 未到達 | トースト: `t("このシナリオは現在の Phase では未実装です", "This scenario is not yet available in the current phase")` |
+| `504 Gateway Timeout` | victim 応答タイムアウト | エラーバナー表示。自動リトライなし |
+| `400 Bad Request` | 入力値検証失敗 | インラインエラー。どのフィールドが原因かを `errorField` で特定し対象フィールドに `border-color: var(--color-danger)` + エラーテキスト表示 |
+| `403 Forbidden` | VICTIM_ALLOWLIST 違反 | インラインエラー: `t("この target は許可されていません", "Target is not in the allowlist")` |
+
+### 6.2 トースト実装
+
+```typescript
+const [toastMessage, setToastMessage] = createSignal<string | null>(null);
+
+// 502 ハンドリング例
+if (res.status === 502) {
+  setToastMessage(t(
+    "victim-web が起動していません。docker compose up -d victim-web を実行してください",
+    "victim-web is not running. Run: docker compose up -d victim-web"
+  ));
+}
+
+// JSX
+<Show when={toastMessage() !== null}>
+  <div
+    class="rhc-toast"
+    role="alert"
+    aria-live="assertive"
+  >
+    <span>{toastMessage()}</span>
+    <button onClick={() => setToastMessage(null)} aria-label={t("閉じる", "Close")}>
+      [×]
+    </button>
+  </div>
+</Show>
+```
+
+---
+
+## 7. 既存コンポーネントへの影響
+
+| コンポーネント | 変更内容 | 影響度 |
+|---|---|---|
+| `AttackPanel.tsx` | `mode` 判定追加。`isLiveMode()` で `RawHttpComposer` / 既存ボタンを排他 `<Show>`。`rawExchange` Signal 追加 | 中 (条件分岐追加) |
+| `EducationalWarningBanner.tsx` | `mode` prop 追加。`mode === "live"` 時の LIVE バッジ表示 | 小 (子要素追加のみ) |
+| `AttackScenarioSelector.tsx` | `scenario.mode` を読んで `[LIVE]` / `[NARRATION]` バッジ表示 | 小 |
+| `DataFlowPanel.tsx` | `tab` Signal に `"sequence"` 追加。`isLiveMode` / `rawExchange` prop 追加。Sequence タブボタン + `SequenceDiagramView` 表示 | 中 |
+| `AttackStepTimeline.tsx` | `mode: "live"` では orchestrator レスポンスの `rawExchange` から `steps[]` を変換する `liveSteps()` 派生値を追加 | 中 |
+| `AttackResultBanner.tsx` | 変更なし (両モードで `AttackResult` を受ける) | なし |
+| `AttackDefensePanel.tsx` | 変更なし | なし |
+
+---
+
+## 8. テスト要件
+
+- [ ] `RawHttpComposer` の target dropdown が `allowedTargets` 以外を選択不可
+- [ ] `RawHttpComposer` の Host ヘッダ入力フィールドが `disabled` 属性を持ち操作できない
+- [ ] headers Signal が `setHeaders(prev => [...prev, newHeader])` パターンで不変更新されている
+- [ ] SEND ボタン押下で `onSend` が正しい payload `{ method, path, headers: Object, body }` で呼ばれる
+- [ ] Raw タブのテキストエリアが `readonly` であり、クリップボード書き込みを行わない
+- [ ] `localStorage.setItem` / `sessionStorage.setItem` が一切呼ばれないこと
+- [ ] `SequenceDiagramView` が 3 アクター (Browser, Orchestrator, Victim) のライフラインを SVG に描画する
+- [ ] `SequenceDiagramView` の矢印クリックで `RawBytesPopup` が表示され、`onClose` で閉じる
+- [ ] `AttackPanel` で `mode === "live"` のとき `RawHttpComposer` が描画され、既存実行ボタンが描画されない
+- [ ] `AttackPanel` で `mode === "narration"` のとき `RawHttpComposer` が描画されない
+- [ ] `EducationalWarningBanner` の LIVE バッジが `mode === "live"` のときのみ表示される
+- [ ] `DataFlowPanel` の Sequence タブが `isLiveMode === false` のとき非表示
+- [ ] `orchestrator` から 502 を受け取ったときトーストが表示される
+- [ ] `orchestrator` から 503 を受け取ったときフェーズ未実装トーストが表示される
+- [ ] D3 transition が `onCleanup` で `interrupt()` キャンセルされる
+
+---
+
+## 9. Solid.js 規約準拠
+
+本セクションは CLAUDE.md `## Solid.js 必須ルール` の要点を RawHttpComposer / SequenceDiagramView に
+特化して確認するチェックリストである。
+
+### 9.1 コンポーネント規約
+
+- [ ] `props.scenarioId`, `props.allowedTargets` など props は常に `props.xxx` 形式でアクセスし、デストラクチャリングしない
+- [ ] 関数コンポーネント内に早期 `return` を置かない。条件分岐は `<Show when={...}>` で代替
+- [ ] コンポーネント関数内のトップレベルに副作用コードを書かない (副作用は `onMount` / `createEffect` / `onCleanup` のみ)
+
+### 9.2 Signal 更新
+
+```typescript
+// OK: 新配列生成
+setHeaders(prev => [...prev, { key: "", value: "" }]);
+setHeaders(prev => prev.filter((_, i) => i !== removeIdx));
+
+// NG: 直接ミューテーション (Signal が再評価されない)
+// headers().push(...)
+// headers()[idx].value = "..."
+```
+
+### 9.3 D3 + Solid 統合
+
+```typescript
+// OK: ref で SVG コンテナ取得 → onMount で D3 初期化
+let svgRef: SVGSVGElement | undefined;
+onMount(() => { d3.select(svgRef!).append("g"); });
+
+// OK: createEffect で Signal 監視 → D3 transition
+createEffect(() => { const ex = props.exchange; /* D3 update */ });
+
+// OK: onCleanup でキャンセル
+onCleanup(() => { d3.select(svgRef!).selectAll("*").interrupt(); });
+
+// NG: D3 が管理する SVG 内部に Solid JSX を挿入
+// <svg ref={svgRef}><circle class="solid-managed" /></svg>  ← 禁止
+```
+
+---
+
+## 10. 関連ファイル
+
+### 上流設計書
+
+| ファイル | 関係 |
+|---|---|
+| `DESIGN/30-live-attack-architecture.md` | live 化全体設計・案 C ハイブリッド採用・コンテナ構成 |
+| `DESIGN/31-orchestrator-spec.md` | `POST /api/orchestrator/exec` リクエスト/レスポンス型・VICTIM_ALLOWLIST 定義 |
+
+### 同列設計書
+
+| ファイル | 関係 |
+|---|---|
+| `DESIGN/32-victim-web-spec.md` | `RawHttpComposer` の target dropdown 候補先エンドポイント定義 |
+| `DESIGN/34-safety-guardrails-live.md` | 本仕様の安全制約 (§2.4) の根拠・live 差分詳細 |
+
+### 既存設計書 (フォーマット参照)
+
+| ファイル | 関係 |
+|---|---|
+| `DESIGN/02-ui-spec.md` | コンポーネント仕様スタイル・ASCII レイアウト・a11y・CSS 変数の参照元 |
+| `DESIGN/04-safety-guardrails.md` | 4 原則・禁止表現 §2.3・バナー要件の基盤 |
+
+### 既存実装ファイル (拡張対象)
+
+| ファイルパス | 変更内容 |
+|---|---|
+| `src/components/shared/AttackPanel.tsx` | `isLiveMode()` 追加、`RawHttpComposer` 組み込み、`rawExchange` Signal |
+| `src/components/shared/EducationalWarningBanner.tsx` | `mode` prop + LIVE バッジ追加 |
+| `src/components/shared/AttackScenarioSelector.tsx` | `[LIVE]` / `[NARRATION]` バッジ追加 |
+| `src/components/shared/DataFlowPanel.tsx` | Sequence タブ + `isLiveMode` / `rawExchange` prop 追加 |
+| `src/components/shared/AttackStepTimeline.tsx` | `liveSteps()` 派生値追加 |
+
+### 新規作成ファイル (本仕様)
+
+| ファイルパス | 役割 |
+|---|---|
+| `src/components/shared/RawHttpComposer.tsx` | リクエスト編集 UI コンポーネント |
+| `src/components/shared/RawHttpComposer.css` | スコープ付きスタイル |
+| `src/components/shared/SequenceDiagramView.tsx` | D3 SVG シーケンス図コンポーネント |
+| `src/components/shared/SequenceDiagramView.css` | スコープ付きスタイル |
+
+### i18n
+
+| ファイルパス | 用途 |
+|---|---|
+| `src/i18n/context.tsx` | `t(ja, en)` ヘルパー。全文言はこれ経由で記述 |

--- a/DESIGN/34-safety-guardrails-live.md
+++ b/DESIGN/34-safety-guardrails-live.md
@@ -1,0 +1,346 @@
+---
+title: 攻撃デモカタログ — live モード安全装置 (DESIGN/04 への差分)
+phase: design
+audience: 開発者・コンテンツレビュアー
+last-updated: 2026-05-02
+safety-reviewed: false
+---
+
+# 34. live モード安全装置 (DESIGN/04 への差分仕様)
+
+## 1. 目的とスコープ
+
+### 1.1 本ファイルの位置付け
+
+本ファイルは `DESIGN/04-safety-guardrails.md` (以下「DESIGN/04」) への**差分仕様**である。
+DESIGN/04 の 4 原則・UI 文言ルール・ペイロード作成ルール・チェックリストはすべて有効なまま継続する。
+本ファイルは `mode: "live"` シナリオ (Docker victim コンテナと実 HTTP 通信するシナリオ) に固有の
+追加・強化装置のみを記述する。
+
+### 1.2 適用対象
+
+- **対象**: `AttackScenarioMeta.mode === "live"` のシナリオおよびそれを扱う PR
+- **対象外**: `mode: "narration"` のシナリオ (既存のナレーション型は DESIGN/04 のみが適用される)
+
+### 1.3 共存方針
+
+Phase 1-5 の移行期間中、`mode: "live"` シナリオと `mode: "narration"` シナリオが並存する。
+両方のシナリオで DESIGN/04 の安全装置が有効となり、live モードシナリオには追加で本ファイルの
+安全装置が適用される。
+
+### 1.4 読み方
+
+DESIGN/04 を読了した上で本ファイルを参照すること。本ファイル単独では安全要件の全体像は把握できない。
+
+---
+
+## 2. 4 原則の live モード対応 (差分表)
+
+各原則について「DESIGN/04 の規定 / live モードでの追加・強化 / 新規実装箇所」を示す。
+
+### 2.1 隔離 (Isolation) — **強化**
+
+| 項目 | DESIGN/04 の規定 | live モードでの追加・強化 | 実装箇所 |
+|------|----------------|------------------------|---------|
+| fetch 宛先制限 | `/api/<area>/attack/<scenario>` または相対パスのみ | `/api/orchestrator/exec` も許可 (victim への中継専用) | `src/api/client.ts` |
+| 外部通信遮断 | API 規約 (ソフトウェア境界) で制限 | `victim-net: internal: true` による OS レイヤ物理遮断 | `docker-compose.yml` |
+| 攻撃者 → victim 直接通信 | 設計上不可 (orchestrator 経由) | ブラウザ → victim 直接通信が**構造的に不可能** (victim はホスト公開ポートを持たない) | `docker-compose.yml` |
+| URL 偽造防止 | なし (ナレーション型はパス検証のみ) | `VICTIM_ALLOWLIST` (Map 構造) でキー一致のみ許可。ブラウザが URL を直接指定する手段を持たない | `server/routes/orchestrator-exec.ts` |
+| victim DB の混入防止 | `is_attack_sim` 列で正常系を保護 | victim-web が専用 `victim-data.sqlite` を持ち、orchestrator の DB と物理分離。tmpfs マウントのため再起動で確実にクリア | `services/victim-web/Dockerfile` + tmpfs マウント |
+
+**live モードでの OK/NG 例 (DESIGN/04 §1.1 の更新差分):**
+
+```typescript
+// OK: live モードの宛先パターン (新規)
+const res = await apiPost<OrchestratorExecResponse>(
+  "/api/orchestrator/exec",
+  {
+    scenarioId: "jwt-alg-none",
+    target: "victim-web",            // ← VICTIM_ALLOWLIST のキー文字列のみ有効
+    request: { method: "POST", path: "/jwt/verify", headers: { "Content-Type": "application/json" }, body: '{"token":"eyJhbGciOiJub25lIn0..."}' },
+  },
+  SCOPE,
+);
+
+// NG: victim URL を直接指定する (設計上できない・リクエストスキーマで拒否)
+const res = await fetch("http://victim-web:4001/jwt/verify", { ... });   // 403
+
+// NG: VICTIM_ALLOWLIST 外のキー (orchestrator が 403 を返す)
+const res = await apiPost("/api/orchestrator/exec", { target: "http://evil.example", ... }, SCOPE);
+```
+
+### 2.2 明示 (Explicit framing) — **強化**
+
+| 項目 | DESIGN/04 の規定 | live モードでの追加・強化 | 実装箇所 |
+|------|----------------|------------------------|---------|
+| バナー常時表示 | `EducationalWarningBanner` を Attacker View 最上部に固定 | 変更なし (継続必須) | 既存コンポーネント |
+| LIVE バッジ | なし | `mode: "live"` シナリオで `EducationalWarningBanner` 右端に `[LIVE]` バッジを追加表示 | `EducationalWarningBanner.tsx` |
+| シナリオセレクタ | なし | 各エントリに `[LIVE]` / `[SIMULATION]` / `[DEFENSE DEMO]` バッジを表示 | シナリオセレクタコンポーネント |
+| DataFlowPanel Trace タブ | `isAttackMode: true` で赤色ハイライト | `mode: "live"` エントリは追加で赤縁表示 (ハイライト強化) | `DataFlowPanel.tsx` |
+| Sequence タブ | 存在しない | `mode: "live"` シナリオでのみ Sequence タブを表示 (ブラウザ → orchestrator → victim の 3 段フロー図) | `DataFlowPanel.tsx` |
+| victimNote | なし | `_trace.victimNote` として「victim 内部クエリは観測不能」の旨を常に付与 | `server/middleware/trace-logger.ts` |
+
+**LIVE バッジの視覚要件:**
+
+| プロパティ | 仕様 |
+|-----------|------|
+| 背景色 | `#52c41a` (緑) |
+| テキスト色 | `#fff` |
+| テキスト | `LIVE` |
+| 表示条件 | `mode === "live"` シナリオでのみ表示 |
+| `dismissable` | 禁止 (DESIGN/04 §6.2 と同様) |
+
+### 2.3 簡略化 (Simplification) — **要再評価**
+
+| 項目 | DESIGN/04 の規定 | live モードでの判断追加 |
+|------|----------------|----------------------|
+| exploit ステップ省略 | 最終 exploit ステップを省略し「条件が揃った状態」を示す | 継続必須 |
+| ブルートフォース上限 | サーバー側で判定、フロントでループ禁止 | orchestrator 側で bruteforce ループ上限 **20 回**・辞書サイズ **200 件** を強制 (フロント側の制限に加えてサーバー側でも二重ガード) |
+| victim 外利用可能性チェック | 「省略の基準: 教材範囲を超えた実際の攻撃に再利用できるか」を問う | live 化 PR ごとに「**この victim エンドポイントを `victim-web` 外で再利用できるか?**」を必ず問う |
+| Phase 4 TLS / SAML | 規定なし (Phase 4 以降) | TLS ダウングレードデモは TLS 1.0 までに制限。SSLv3 等の実装は victim-tls-proxy にも含めない |
+| live 化の説明文言 | 規定なし | 「実 HTTP が走る」「外部ネットワークには到達しない」の旨を CWE/CAPEC 行の下に必ず併記 |
+
+### 2.4 防御策併記 (Defense pairing) — **維持、live 化対応を追加**
+
+| 項目 | DESIGN/04 の規定 | live モードでの追加 |
+|------|----------------|-------------------|
+| `AttackDefensePanel` 自動展開 | 攻撃完了後に自動展開 | live モードでも継続 (変更なし) |
+| 防御コードリンク | `server/routes/<area>.ts` の堅牢実装への参照 | victim-web の修正コード (`services/victim-web/src/routes/<area>-vuln.ts` の該当箇所) も表示 |
+| 副ボタン (将来) | なし | Phase 3 以降検討: 「同じ raw HTTP を堅牢版エンドポイントに送って 401 を見る」副ボタン |
+
+---
+
+## 3. 開発レビューチェックリスト §4.1〜4.5 の更新差分
+
+DESIGN/04 §4 のチェックリストに対して、`mode: "live"` を含む PR で適用される追加項目を以下に示す。
+DESIGN/04 §4 の全項目は引き続き必須であり、本節はそれに追加する形で適用する。
+
+### 3.1 §4.1 隔離チェック (差分)
+
+- [ ] `apiPost` / `apiGet` の宛先が `/api/orchestrator/exec` または `/api/<area>/attack/<scenario>` (ナレーション型維持シナリオ) のいずれか
+- [ ] orchestrator の Request に渡す `target` 値が `VICTIM_ALLOWLIST` に登録済みのキー文字列
+- [ ] `docker network inspect victim-net` で `Internal: true` が確認できる
+- [ ] `docker compose ps` で victim コンテナの公開ポート列が空 (ホストへの公開なし)
+- [ ] `services/<victim-name>/Dockerfile` に外部 URL への `RUN curl` / `RUN wget` が含まれない
+- [ ] 攻撃シナリオで発生した victim 側書き込みが orchestrator の `server/db/data.sqlite` に混入しない設計になっている
+- [ ] (Phase 1-2 のみ) `dev:no-docker` フォールバックで当該シナリオが `LIVE モード未対応` と明示エラーを出す
+
+### 3.2 §4.2 表示・文言チェック (差分)
+
+- [ ] `EducationalWarningBanner` の右端に `[LIVE]` バッジが `mode: "live"` シナリオでのみ表示される
+- [ ] バッジが `mode: "narration"` シナリオで表示されないことを確認 (誤表示チェック)
+- [ ] シナリオセレクタの各エントリに mode バッジが正しく表示される
+- [ ] DataFlowPanel に Sequence タブが `mode: "live"` シナリオでのみ表示される
+- [ ] DataFlowPanel の Trace タブで `mode: "live"` 由来のエントリに赤縁表示が適用される
+- [ ] シナリオ説明文に「実 HTTP が走る」「外部ネットワークには到達しない」の旨が CWE/CAPEC 行の下に記載されている
+
+### 3.3 §4.3 教育内容チェック (差分)
+
+DESIGN/04 §4.3 の項目を継続。追加:
+
+- [ ] live モード時に「実 HTTP が走る」「外部ネットワークには到達しない」の旨が CWE/CAPEC 行の直下に 1 文以上で記述されている
+- [ ] `_trace.victimNote` が「victim コンテナ内部の DB クエリ・暗号操作は orchestrator から観測不能です」に相当する文言で設定されている
+
+### 3.4 §4.4 ペイロードチェック (差分)
+
+- [ ] `RawHttpComposer` に export ボタンが**存在しない** (ペイロード持ち出し阻止)
+- [ ] `RawHttpComposer` に copy-to-clipboard ボタンが**存在しない**
+- [ ] `orchestrator-exec.ts` の `attack_log` 書き込みが `scenarioId`, `outcome`, `elapsedMs`, `targetResolvedTo` の summary のみ (raw bytes 非永続化)
+- [ ] `RawHttpComposer` の編集中コンテンツが `localStorage` / `sessionStorage` に保存されない
+- [ ] bruteforce 系シナリオで orchestrator 側のループ上限が 20 回・辞書サイズが 200 件を超えていない
+- [ ] Phase 4 の TLS 系シナリオで victim-tls-proxy が TLS 1.0 より古いプロトコルを有効にしていない
+
+### 3.5 §4.5 ログ・デバッグチェック (差分)
+
+DESIGN/04 §4.5 の項目を継続。追加:
+
+- [ ] `orchestrator-exec.ts` の `console.log` に raw bytes が出力されない
+- [ ] `_trace` の `victimNote` が `mode: "live"` 時に常に設定されている
+- [ ] victim-web コンテナのログに実ユーザーの認証情報が出力されない設計になっている
+
+---
+
+## 4. 新規安全装置一覧 (live モード固有)
+
+| 装置 | 実装場所 | 理由 | 検証方法 |
+|------|---------|------|---------|
+| `victim-net: internal: true` | `docker-compose.yml` | OS レイヤで victim からのインターネット egress を物理遮断 | `docker network inspect victim-net` → `"Internal": true` 確認 |
+| `VICTIM_ALLOWLIST` (ReadonlyMap 構造) | `server/routes/orchestrator-exec.ts` | URL 偽造防止: target はキー文字列一致のみ許可、baseUrl は allowlist から取得 | unit test で不在キー → 403 `target_not_in_allowlist` |
+| victim ホストポート非公開 | `docker-compose.yml` の victim サービス定義 | ブラウザから victim への直接通信を構造上不可にする | `docker compose ps` で victim の PORTS 列が空 |
+| `attacker-shell` 最小権限 | `docker-compose.yml` の attacker-shell サービス定義 | コンテナ脱出耐性: `--read-only --cap-drop=ALL --pids-limit=64 --security-opt no-new-privileges:true` | `docker inspect attacker-shell` で各設定確認 |
+| Production guard (`productionGuard` middleware) | `server/middleware/production-guard.ts` (新規) | `NODE_ENV === "production"` で 503 返却、本番誤起動防止 | unit test で `NODE_ENV=production` 設定時に 503 |
+| `Host` ヘッダ強制上書き | `server/routes/orchestrator-exec.ts` の `proxyToVictim()` 内 | DNS rebinding 予防。ブラウザ送信の Host を破棄し baseUrl の hostname:port に強制置換 | unit test でブラウザ指定の偽 Host → allowlist 値に上書きされることを確認 |
+| `attack_log` 永続化禁止 (raw bytes) | `server/routes/orchestrator-exec.ts` の DB 書き込みロジック | PII・クレデンシャルの DB 流入防止。双方向 raw bytes (browser⇄orchestrator + orchestrator⇄victim) を全てリクエスト処理中のメモリのみで保持し、`attack_log` テーブルには summary のみ書込み | DB schema 確認 + `attack_log` INSERT SQL に raw bytes 列が存在しないことを確認 |
+| `RawHttpComposer` 持ち出し阻止 | `src/components/shared/RawHttpComposer.tsx` | export ボタン・copy-to-clipboard・sessionStorage 保存を実装しない | UI test で各機能の不在確認 |
+| `victim-data.sqlite` 物理分離 | `services/victim-web/Dockerfile` + tmpfs マウント (再起動で確実にクリア、PII / 攻撃データ流入の永続化を物理的に防止) | orchestrator DB との混入防止。ボリューム永続化なし | コンテナ内 `ls` で `/app/victim-data.sqlite` のみ存在、orchestrator DB と別パスであること。`docker inspect victim-web` でマウントタイプが `tmpfs` であることを確認 |
+| Healthcheck (`GET /health`) | `services/victim-web/src/index.ts` + `docker-compose.yml` の `healthcheck` | orchestrator が victim 起動を待機し、起動失敗を早期検出 | `docker compose ps` で STATUS が `healthy` であることを確認 |
+| `shared/api-types.ts` のみ import 許可 | `services/victim-web/` の eslint 設定 | victim から orchestrator の内部実装 (`server/routes/*`) への参照禁止 | lint rule `no-restricted-imports` で `server/` パスへの import をエラー化 |
+| `timeoutMs` 上限強制 | `server/routes/orchestrator-exec.ts` の zod スキーマ | victim に対する意図的な長時間接続を防止。最大 10000 ms | zod バリデーション + unit test |
+| Phase guard (`phaseAvailable` 検証) | `server/routes/orchestrator-exec.ts` | 未実装 Phase の victim を誤って呼び出すことを防止 | unit test: `LIVE_ATTACK_PHASE=1` で `victim-tls-proxy` を指定 → 503 `phase_not_reached` |
+
+---
+
+## 5. `is_attack_sim` フラグの将来削除検討 (Phase 5)
+
+### 5.1 現状 (DESIGN/04 §5.3)
+
+DESIGN/04 §5.3 では、以下の 6 テーブルに `is_attack_sim INTEGER NOT NULL DEFAULT 0` 列を追加し、
+正常系クエリは `WHERE is_attack_sim = 0` で攻撃データを除外する設計としている。
+
+| テーブル |
+|---------|
+| `sessions` |
+| `oauth_codes` |
+| `oauth_tokens` |
+| `api_keys` |
+| `kerberos_tickets` |
+| `refresh_tokens` |
+
+### 5.2 live 化による状況変化
+
+live モードでは victim-web が専用の `victim-data.sqlite` を持つため、
+live シナリオによる攻撃データが orchestrator 側の DB に書き込まれない。
+つまり、**live 化が完了したシナリオについては `is_attack_sim` 列が不要になる**。
+
+### 5.3 Phase 5 の判断ポイント
+
+| 状況 | 方針 |
+|------|------|
+| A/B 群 23 件が全て live 化完了 | `is_attack_sim` 列削除の DDL マイグレーションを検討 |
+| C 群 11 件がナレーション型を維持 | ナレーション型が DB 書き込みを伴わない設計に再評価できるか検証し、削除可否を判断 |
+
+### 5.4 削除する場合のマイグレーション戦略
+
+SQLite は `ALTER TABLE DROP COLUMN` が 3.35.0 以降でのみ利用可能であり、古い環境向けには
+テーブル再構築 (CREATE → INSERT → DROP → RENAME) が必要。Phase 5 設計時に better-sqlite3 の
+対象バージョンを確認し、idempotent なマイグレーション関数を `server/db/schema.ts` に追加する。
+DESIGN/04 §5.3.4 の `WHERE is_attack_sim = 0` 句が適用される 12 件超のクエリ箇所 (`server/db/queries.ts`, `server/index.ts`, `server/routes/{token-auth,session-auth,oauth-sim,sso-apikey,kerberos-sim}.ts`) も同時に修正対象。
+
+---
+
+## 6. PR テンプレート反映 (差分)
+
+`.github/pull_request_template.md` (Phase 1 で新規作成) に以下のセクションを含める。
+
+```markdown
+## live モード PR チェックリスト
+
+> このセクションは `AttackScenarioMeta.mode === "live"` のシナリオを含む PR にのみ適用する。
+> ナレーション型のみの PR はこのセクションをスキップし「N/A」と記入する。
+
+### DESIGN/34 §3 チェックリスト
+- [ ] §3.1 隔離チェック (差分) — 全項目
+- [ ] §3.2 表示・文言チェック (差分) — 全項目
+- [ ] §3.3 教育内容チェック (差分) — 全項目
+- [ ] §3.4 ペイロードチェック (差分) — 全項目
+- [ ] §3.5 ログ・デバッグチェック (差分) — 全項目
+
+### victim-web 変更時の追加確認
+- [ ] `services/victim-web/` への変更がある場合、対応するシナリオの堅牢実装リンクが `AttackDefensePanel` から表示できる
+- [ ] `docker compose up -d` 後に `docker compose ps` で victim コンテナの PORTS 列が空 (ホストへの公開なし)
+- [ ] `docker network inspect victim-net` で `"Internal": true`
+
+### Docker 環境確認
+- [ ] `docker compose up -d` で全コンテナが `healthy` 状態になる
+- [ ] (Phase 3+) `npm run dev:no-docker` 廃止後の動作確認方法を PR 説明に記載
+
+### DESIGN/04 既存チェックリスト
+- [ ] §4.1〜4.5 の全項目 (DESIGN/04-safety-guardrails.md を参照)
+```
+
+---
+
+## 7. safety-reviewed フラグの運用 (拡張)
+
+### 7.1 DESIGN/30-34 への適用
+
+DESIGN/30-34 の各ファイルは `safety-reviewed: false` で初期化されており、
+DESIGN/04 §4.6 と同じフローで `safety-reviewed: true` への移行を管理する。
+
+| ファイル | safety-reviewed の条件 |
+|---------|----------------------|
+| `DESIGN/30-live-attack-architecture.md` | アーキテクチャ設計の安全性をチームでレビュー完了後 |
+| `DESIGN/31-orchestrator-spec.md` | VICTIM_ALLOWLIST・production guard・Host 強制の実装が unit test で検証済み後 |
+| `DESIGN/32-victim-web-spec.md` | victim エンドポイントが「教材外で再利用できない」判断を経た後 |
+| `DESIGN/33-raw-http-composer.md` | export/copy/persist 全禁止の UI 実装確認後 |
+| `DESIGN/34-safety-guardrails-live.md` (本ファイル) | §4 の全安全装置の実装が確認された後 |
+
+### 7.2 live 化 PR 時の既存ファイルのリセット
+
+既存の `DESIGN/10-21` 各タブ別ファイルに対して live 化対応 PR が出る際は、
+対象ファイルの `safety-reviewed` を `false` にリセットし、live 版の安全レビューが完了した後に
+改めて `true` に設定する。
+
+```yaml
+# live 化 PR マージ前のリセット例
+---
+safety-reviewed: false   # live 版の安全レビューが必要
+---
+```
+
+---
+
+## 8. 将来拡張への影響
+
+### 8.1 L1/L2 深掘りへの適用
+
+NAND シミュレーター・ブレッドボード UI・NBIT CPU エミュレーター等の将来追加モジュールは
+本仕様のスコープ外だが、`services/` 同枠で追加される場合は以下のパターンを踏襲することを推奨する。
+
+| 安全装置パターン | 適用推奨 |
+|---------------|---------|
+| `victim-net` 同等の internal network | 外部への通信が発生し得るコンテナに適用 |
+| target allowlist (Map 構造) | orchestrator 経由でコンテナを操作する場合に適用 |
+| production guard | 教育用ローカル専用のルートすべてに適用 |
+| ホストポート非公開 | 学習者がブラウザから直接到達すべきでないコンテナに適用 |
+
+### 8.2 victim 数増加時の `VICTIM_ALLOWLIST` 管理
+
+将来 victim コンテナ数が増えた場合 (Phase 4 の `victim-tls-proxy`, `victim-saml-idp` 等)、
+以下の管理手順を別途文書化することを推奨する。
+
+- allowlist エントリ追加時の単体テスト (不在キー → 403 を保証)
+- 新規 victim の `phaseAvailable` 設定レビュー
+- CI での `docker compose ps` によるヘルスチェック確認
+
+---
+
+## 9. 既存 DESIGN/04 への変更要否
+
+### 9.1 基本方針
+
+本ファイルは差分仕様であり、**DESIGN/04 本体は基本的に変更しない**。
+
+### 9.2 DESIGN/04 §2.3 禁止表現一覧への追記検討
+
+live 化で以下の表現が誘発されやすくなるため、DESIGN/04 §2.3 への追記を推奨する。
+
+| 追記候補の禁止表現 | live 化での誘発シーン | 代替表現 |
+|-----------------|---------------------|---------|
+| 「実際にハックする」 | RawHttpComposer の説明文や操作ガイド | 「実 HTTP リクエストを組み立てて概念実証を確認する」 |
+| 「本物の HTTP で攻撃」 | AttackResultBanner の成功表示 | 「脆弱な設定のエンドポイントに対して HTTP リクエストを送信し、攻撃が成立する条件を確認しました」 |
+| 「Docker があれば本物の攻撃ができる」 | シナリオの導入文 | 「教育用に隔離された環境でプロトコルの脆弱性を体験します」 |
+
+### 9.3 DESIGN/04 §4.6 への追記推奨
+
+DESIGN/04 §4.6 (safety-reviewed フラグ運用) に以下の一文の追加を推奨する。
+
+> 「DESIGN/30-34 (live 化仕様シリーズ) も同じレビューフローを適用し、各ファイルの `safety-reviewed` フラグを管理する。」
+
+---
+
+## 10. 関連ファイル
+
+| 種別 | ファイル | 関係 |
+|------|---------|------|
+| 基底 | `DESIGN/04-safety-guardrails.md` | 本ファイルが拡張する基盤仕様。本ファイル単独では不完全 |
+| 上流アーキテクチャ | `DESIGN/30-live-attack-architecture.md` | 本ファイルが安全装置を提供する対象の全体設計 |
+| 同列 | `DESIGN/31-orchestrator-spec.md` | VICTIM_ALLOWLIST・production guard・Host 強制の詳細実装仕様 |
+| 同列 | `DESIGN/32-victim-web-spec.md` | victim-web 隔離方針・エンドポイント定義 |
+| 同列 | `DESIGN/33-raw-http-composer.md` | RawHttpComposer UI 安全制約 (export 禁止・persist 禁止) |
+| 既存実装 | `server/db/schema.ts` | `is_attack_sim` 列定義 (§5 の削除検討対象) |
+| 既存実装 | `server/middleware/trace-logger.ts` | `_trace` 付与・`setLiveMode()` 追加対象 |
+| 既存実装 | `src/components/shared/EducationalWarningBanner.tsx` | LIVE バッジ追加対象 |
+| 既存実装 | `src/components/shared/DataFlowPanel.tsx` | Sequence タブ追加・赤縁表示強化対象 |
+| 将来 | `.github/pull_request_template.md` | §6 の PR チェックリスト反映先 |
+| 作業状態 | `CHECKPOINT.md` | Phase ロードマップ・確定意思決定の管理ファイル |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,13 @@ services:
 networks:
   victim-net:
     driver: bridge
-    # OS レイヤで victim-net からのインターネット egress を遮断 (DESIGN/34 §4)。
-    # `internal: true` は外向き egress のみブロックし、host からの ingress (上記 127.0.0.1:4001 binding) は許可する。
-    # よって victim 内部から外部 URL に curl/fetch することは不可能なまま、host 上の orchestrator は
-    # victim を呼び出せる。
-    internal: true
+    # ─────────────────────────────────────────────────────────────────────
+    # Phase 1-2 トレードオフ: `internal: true` を有効化すると Docker は
+    # host からの port publishing も無効化する仕様 (compose ドキュメント明記)。
+    # 本 Phase では orchestrator が host (port 3001) で動作しており host loopback で
+    # victim-web に到達する必要があるため、暫定的に `internal` を無効化する。
+    # ただし DESIGN/34 §4 の「OS レイヤ egress 遮断」は弱まるため、Phase 3+ で
+    # orchestrator も compose 内のサービス化したタイミングで `internal: true` を復活させる。
+    # その時点でこの `ports` 公開も削除し DESIGN/32 §6.1 の `ports: []` に戻す。
+    # internal: true   # ← Phase 3+ で復活
+    # ─────────────────────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,70 @@
+# 教育用 live attack 環境の docker-compose 定義
+# 関連設計書: DESIGN/30 §2.2-2.3, DESIGN/32 §6, DESIGN/34 §4
+#
+# Phase 1 で起動: victim-web, attacker-shell
+# Phase 4 で追加予定: victim-tls-proxy, victim-saml-idp
+#
+# orchestrator (host:3001) は本ファイルでは管理せず、host で `npm run dev:server` する想定。
+# Phase 1-2 の Windows 開発体験のため、orchestrator は docker compose 経由では起動しない。
+
+services:
+  victim-web:
+    build:
+      context: .
+      dockerfile: services/victim-web/Dockerfile
+    networks:
+      - victim-net
+    # Phase 1 注記: orchestrator が host (port 3001) で動作するため、loopback (127.0.0.1) にのみ
+    # victim-web を露出する。外部 NIC には公開しない。Phase 3+ で orchestrator も docker 化された
+    # 際は本 ports セクションを削除し、`internal: true` の victim-net 内部通信のみで完結させる。
+    # DESIGN/32 §6.1 "ports: []" の最終形は Phase 3+ で達成。
+    ports:
+      - "127.0.0.1:4001:4001"
+    environment:
+      NODE_ENV: development
+      # docker 内では PORT 衝突がないが、宣言を明示する
+      VICTIM_PORT: "4001"
+    volumes:
+      - type: tmpfs
+        target: /app/data
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+    mem_limit: 256m
+    pids_limit: 128
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:4001/health"]
+      interval: 10s
+      timeout: 2s
+      retries: 3
+
+  attacker-shell:
+    build:
+      context: .
+      dockerfile: services/attacker-shell/Dockerfile
+    networks:
+      - victim-net
+    # ports: 公開しない
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+    mem_limit: 64m
+    pids_limit: 64
+    command: ["sleep", "infinity"]
+
+networks:
+  victim-net:
+    driver: bridge
+    # OS レイヤで victim-net からのインターネット egress を遮断 (DESIGN/34 §4)。
+    # `internal: true` は外向き egress のみブロックし、host からの ingress (上記 127.0.0.1:4001 binding) は許可する。
+    # よって victim 内部から外部 URL に curl/fetch することは不可能なまま、host 上の orchestrator は
+    # victim を呼び出せる。
+    internal: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "osi-reference",
       "version": "0.1.0",
+      "workspaces": [
+        "services/*"
+      ],
       "dependencies": {
         "@hono/node-server": "^1.19.13",
         "@simplewebauthn/browser": "^13.3.0",
@@ -14,7 +17,6 @@
         "@solidjs/router": "^0.16.1",
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.8.0",
-        "concurrently": "^9.2.1",
         "d3-selection": "^3.0.0",
         "d3-transition": "^3.0.1",
         "hono": "^4.12.12",
@@ -35,6 +37,7 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/qrcode": "^1.5.6",
         "@types/uuid": "^10.0.0",
+        "concurrently": "^9.2.1",
         "jsdom": "^29.0.1",
         "tsx": "^4.21.0",
         "typescript": "^5.7.0",
@@ -2441,6 +2444,14 @@
         "tslib": "^2.3.1"
       }
     },
+    "node_modules/@osi-ref/attacker-shell": {
+      "resolved": "services/attacker-shell",
+      "link": true
+    },
+    "node_modules/@osi-ref/victim-web": {
+      "resolved": "services/victim-web",
+      "link": true
+    },
     "node_modules/@peculiar/asn1-android": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.6.0.tgz",
@@ -4058,6 +4069,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4074,6 +4086,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4089,6 +4102,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4107,6 +4121,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -4156,6 +4171,7 @@
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
       "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
@@ -4793,6 +4809,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5247,6 +5264,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7083,6 +7101,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -7299,6 +7318,7 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
       "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7784,6 +7804,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -7985,6 +8006,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
@@ -9541,6 +9563,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -9558,6 +9581,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -9596,6 +9620,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -9612,6 +9637,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -9630,6 +9656,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -9642,6 +9669,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "services/attacker-shell": {
+      "name": "@osi-ref/attacker-shell",
+      "version": "0.1.0"
+    },
+    "services/victim-web": {
+      "name": "@osi-ref/victim-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "@hono/node-server": "^1.19.13",
+        "hono": "^4.12.12",
+        "jsonwebtoken": "^9.0.3"
+      },
+      "devDependencies": {
+        "@types/jsonwebtoken": "^9.0.10"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9684,8 +9684,28 @@
         "jsonwebtoken": "^9.0.3"
       },
       "devDependencies": {
-        "@types/jsonwebtoken": "^9.0.10"
+        "@types/jsonwebtoken": "^9.0.10",
+        "@types/node": "^22.0.0",
+        "tsx": "^4.21.0",
+        "typescript": "^5.7.0"
       }
+    },
+    "services/victim-web/node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "services/victim-web/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,14 +3,21 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "workspaces": [
+    "services/*"
+  ],
   "scripts": {
-    "dev": "concurrently \"vite\" \"tsx watch server/index.ts\"",
+    "dev": "docker compose up -d victim-web && concurrently \"vite\" \"tsx watch server/index.ts\"",
+    "dev:no-docker": "concurrently \"vite\" \"tsx watch server/index.ts\" \"npm --workspace=@osi-ref/victim-web run dev\"",
     "dev:client": "vite",
     "dev:server": "tsx watch server/index.ts",
+    "dev:victim": "npm --workspace=@osi-ref/victim-web run dev",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest",
-    "test:ci": "vitest run"
+    "test:ci": "vitest run",
+    "victim:reset": "docker compose restart victim-web",
+    "victim:logs": "docker compose logs -f victim-web"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.13",

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,8 @@ import { cors } from "hono/cors";
 import { serve } from "@hono/node-server";
 import { traceMiddleware } from "./middleware/trace-logger.js";
 import { ensureAttackEnabled } from "./middleware/attack-guard.js";
+import { productionGuard } from "./middleware/production-guard.js";
+import { orchestratorExecRoutes } from "./routes/orchestrator-exec.js";
 import { getDb, seedDb } from "./db/schema.js";
 import { passwordAuthRoutes } from "./routes/password-auth.js";
 import { jwtOpsRoutes } from "./routes/jwt-ops.js";
@@ -31,8 +33,10 @@ app.use("/api/*", async (c, next) => {
   await next();
 });
 app.use("/api/*", traceMiddleware);
+app.use("/api/orchestrator/*", productionGuard);
 
 // ── Routes ──
+app.route("/api/orchestrator", orchestratorExecRoutes);
 app.route("/api/auth/password", passwordAuthRoutes);
 app.route("/api/jwt", jwtOpsRoutes);
 app.route("/api/session", sessionAuthRoutes);

--- a/server/middleware/production-guard.ts
+++ b/server/middleware/production-guard.ts
@@ -1,0 +1,19 @@
+/**
+ * Production guard for /api/orchestrator/*
+ *
+ * NODE_ENV === "production" のとき 503 を返す。
+ * 教育用ローカル環境専用エンドポイントが本番デプロイされた場合の防護線。
+ *
+ * 関連設計書: DESIGN/31 §8, DESIGN/34 §4
+ */
+import type { Context, Next } from "hono";
+
+export async function productionGuard(ctx: Context, next: Next) {
+  if (process.env.NODE_ENV === "production") {
+    return ctx.json(
+      { success: false, error: "live_attack_disabled_in_production" },
+      503,
+    );
+  }
+  await next();
+}

--- a/server/middleware/trace-logger.ts
+++ b/server/middleware/trace-logger.ts
@@ -17,6 +17,11 @@ export interface TraceCollector {
    * 両方に同一値を共有させることが可能 (ROB-FIND-009 対応)。
    */
   addAttackStep(step: AttackStep | Omit<AttackStep, "timestamp">): void;
+  /**
+   * orchestrator/exec ルートが呼び出す。`mode: "live"` と `victimNote` を _trace に付与する。
+   * DESIGN/31 §7.1 の TraceCollector 拡張。
+   */
+  setLiveMode(): void;
   getTrace(): ServerTrace;
 }
 
@@ -25,6 +30,7 @@ function createTraceCollector(): TraceCollector {
   const cryptoOps: CryptoOp[] = [];
   const sessionOps: SessionOp[] = [];
   const attackSteps: AttackStep[] = [];
+  let liveMode = false;
 
   return {
     addDbQuery(q) { dbQueries.push(q); },
@@ -36,12 +42,18 @@ function createTraceCollector(): TraceCollector {
         : Date.now();
       attackSteps.push({ ...step, timestamp: ts });
     },
+    setLiveMode() { liveMode = true; },
     getTrace() {
       const trace: ServerTrace = {};
       if (dbQueries.length) trace.dbQueries = dbQueries;
       if (cryptoOps.length) trace.cryptoOps = cryptoOps;
       if (sessionOps.length) trace.sessionOps = sessionOps;
       if (attackSteps.length) trace.attackSteps = attackSteps;
+      if (liveMode) {
+        trace.mode = "live";
+        trace.victimNote =
+          "victim コンテナ内部の DB クエリ・暗号操作は orchestrator から観測不能です";
+      }
       return trace;
     },
   };
@@ -63,7 +75,10 @@ export async function traceMiddleware(ctx: Context, next: Next) {
   if (contentType.includes("application/json")) {
     const body = await ctx.res.json();
     const trace = collector.getTrace();
-    const isAttackPath = ctx.req.path.includes("/attack/");
+    // DESIGN/31 §7.1: orchestrator/exec ルートも attack path として扱う
+    const isAttackPath =
+      ctx.req.path.includes("/attack/") ||
+      ctx.req.path.startsWith("/api/orchestrator/");
     const hasAnyOps = Object.keys(trace).length > 0;
     if (hasAnyOps || isAttackPath) {
       if (isAttackPath) trace.isAttackMode = true;

--- a/server/routes/orchestrator-exec.ts
+++ b/server/routes/orchestrator-exec.ts
@@ -1,0 +1,397 @@
+/**
+ * Orchestrator route: POST /api/orchestrator/exec
+ *
+ * 【教育目的専用】
+ * このファイルは OSI 参照アプリの教材機能として、
+ * ブラウザの RawHttpComposer が組み立てた raw HTTP リクエストを
+ * VICTIM_ALLOWLIST で限定された victim コンテナへ中継するプロキシです。
+ *
+ * - ブラウザは target キー文字列のみ送信可能 (URL 偽造防止)
+ * - baseUrl は orchestrator が allowlist から取得 (環境変数による上書き禁止)
+ * - Host ヘッダは強制上書き (DNS rebinding 予防)
+ * - raw bytes は browser⇄orchestrator + orchestrator⇄victim の双方向で
+ *   メモリ上のみ保持し、永続化しない
+ *
+ * 関連設計書: DESIGN/31, DESIGN/34
+ */
+import { Hono } from "hono";
+import { z } from "zod";
+import * as http from "node:http";
+import * as https from "node:https";
+import type {
+  OrchestratorExecRequest,
+  OrchestratorExecResponse,
+  RawExchange,
+  RawHttpRequest,
+  RawHttpResponse,
+  VictimEntry,
+  VictimTarget,
+  AttackStep,
+} from "../../shared/api-types.js";
+
+export const orchestratorExecRoutes = new Hono();
+
+// ── VICTIM_ALLOWLIST (DESIGN/31 §5.1) ─────────────────────────────────
+const VICTIM_ALLOWLIST: ReadonlyMap<VictimTarget, VictimEntry> = new Map([
+  [
+    "victim-web",
+    {
+      // docker compose 環境では `victim-web` の DNS、dev:no-docker 環境では localhost を解決する。
+      // VICTIM_WEB_BASE_URL は test 用 override のみ許可 (本番デプロイ時は使われない)。
+      baseUrl: process.env.VICTIM_WEB_BASE_URL ?? "http://localhost:4001",
+      network: "victim-net",
+      phaseAvailable: 1,
+    },
+  ],
+  [
+    "attacker-shell",
+    {
+      baseUrl: "exec://attacker-shell",
+      network: "victim-net",
+      phaseAvailable: 2, // Phase 1 では HTTP プロキシ未対応 (Phase 2 で docker exec 対応予定)
+    },
+  ],
+] as const);
+
+// ── Phase ガード ─────────────────────────────────────────────────────
+const CURRENT_PHASE = (() => {
+  const env = process.env.LIVE_ATTACK_PHASE;
+  const parsed = env ? Number(env) : 1;
+  if (![1, 2, 3, 4, 5].includes(parsed)) return 1;
+  return parsed as 1 | 2 | 3 | 4 | 5;
+})();
+
+// ── zod スキーマ (DESIGN/31 §3.1) ─────────────────────────────────────
+const HTTP_METHOD_VALUES = [
+  "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS",
+] as const;
+
+const VICTIM_TARGET_VALUES: readonly VictimTarget[] = [
+  "victim-web", "attacker-shell", "victim-tls-proxy", "victim-saml-idp",
+] as const;
+
+const orchestratorExecRequestSchema = z.object({
+  scenarioId: z.string().min(1).max(64),
+  target: z.enum(VICTIM_TARGET_VALUES as unknown as [VictimTarget, ...VictimTarget[]]),
+  request: z.object({
+    method: z.enum(HTTP_METHOD_VALUES),
+    path: z.string().regex(/^\//, "path must start with /").max(1024),
+    headers: z.record(z.string(), z.string()),
+    body: z.union([z.string(), z.null()]).optional(),
+  }),
+  timeoutMs: z.number().int().min(100).max(10000).optional(),
+});
+
+// ── route handler ────────────────────────────────────────────────────
+orchestratorExecRoutes.post("/exec", async (c) => {
+  const trace = c.get("trace");
+  trace.setLiveMode();
+
+  // 1. Body parse + validation
+  let json: unknown;
+  try {
+    json = await c.req.json();
+  } catch {
+    return c.json({ success: false, error: "invalid_json_body" }, 400);
+  }
+
+  const parsed = orchestratorExecRequestSchema.safeParse(json);
+  if (!parsed.success) {
+    return c.json(
+      {
+        success: false,
+        error: "schema_validation_failed",
+        validationErrors: parsed.error.issues,
+      },
+      400,
+    );
+  }
+  const req: OrchestratorExecRequest = {
+    scenarioId: parsed.data.scenarioId,
+    target: parsed.data.target,
+    request: {
+      method: parsed.data.request.method,
+      path: parsed.data.request.path,
+      headers: parsed.data.request.headers,
+      body: parsed.data.request.body ?? null,
+    },
+    timeoutMs: parsed.data.timeoutMs ?? 3000,
+  };
+
+  // 2. VICTIM_ALLOWLIST 検証
+  const entry = VICTIM_ALLOWLIST.get(req.target);
+  if (!entry) {
+    // セキュリティログ: 不在キーは URL 偽造試行の可能性。target 値はレスポンスに含めない (情報漏洩防止)
+    console.warn(
+      `[orchestrator] target_not_in_allowlist scenarioId=${req.scenarioId}`,
+    );
+    return c.json(
+      {
+        success: false,
+        error: "target_not_in_allowlist",
+        _trace: {
+          mode: "live",
+          isAttackMode: true,
+          victimNote: "不正な target 値の可能性あり",
+        },
+      },
+      403,
+    );
+  }
+
+  // 3. Phase ガード
+  if (entry.phaseAvailable > CURRENT_PHASE) {
+    return c.json(
+      {
+        success: false,
+        error: "phase_not_reached",
+        requiredPhase: entry.phaseAvailable,
+        currentPhase: CURRENT_PHASE,
+      },
+      503,
+    );
+  }
+
+  // 4. exec:// (docker exec) は Phase 2+ で実装。Phase 1 では未対応として 503 を返す
+  if (entry.baseUrl.startsWith("exec://")) {
+    return c.json(
+      {
+        success: false,
+        error: "exec_target_not_implemented",
+        detail: "attacker-shell exec routing arrives in Phase 2",
+      },
+      503,
+    );
+  }
+
+  // 5. raw HTTP プロキシ
+  const startedAt = Date.now();
+  let proxyResult: ProxyResult;
+  try {
+    proxyResult = await proxyToVictim(entry, req.request, req.timeoutMs ?? 3000);
+  } catch (err) {
+    const code = err instanceof Error ? err.message : "unknown_error";
+    if (code === "victim_timeout") {
+      return c.json(
+        { success: false, error: "victim_timeout", timeoutMs: req.timeoutMs ?? 3000 },
+        504,
+      );
+    }
+    return c.json(
+      { success: false, error: "victim_unreachable", detail: code },
+      502,
+    );
+  }
+  const finishedAt = Date.now();
+
+  // 6. AttackStep 生成 (probe → exploit/blocked → verify)
+  const victimStatus = proxyResult.exchange.orchestratorToVictim.response.status;
+  const attackSucceeded = victimStatus >= 200 && victimStatus < 300;
+
+  const probeStep: AttackStep = {
+    id: `${req.scenarioId}-probe`,
+    kind: "probe",
+    label: `Sent ${req.request.method} ${req.request.path} to ${req.target}`,
+    labelJa: `${req.target} に ${req.request.method} ${req.request.path} を送信`,
+    status: "success",
+    payload: {
+      type: "http",
+      request: {
+        method: req.request.method,
+        url: `${entry.baseUrl}${req.request.path}`,
+        headers: proxyResult.exchange.orchestratorToVictim.request.headers,
+        body: req.request.body,
+      },
+    },
+    timestamp: startedAt,
+  };
+  trace.addAttackStep(probeStep);
+
+  const outcomeStep: AttackStep = {
+    id: `${req.scenarioId}-${attackSucceeded ? "exploit" : "blocked"}`,
+    kind: attackSucceeded ? "exploit" : "blocked",
+    label: attackSucceeded
+      ? `victim returned ${victimStatus} — attack condition met`
+      : `victim returned ${victimStatus} — defense engaged`,
+    labelJa: attackSucceeded
+      ? `victim が ${victimStatus} を返却 — 攻撃成立条件を満たした`
+      : `victim が ${victimStatus} を返却 — 防御が機能`,
+    status: attackSucceeded ? "success" : "blocked",
+    payload: {
+      type: "http",
+      response: {
+        status: victimStatus,
+        headers: proxyResult.exchange.orchestratorToVictim.response.headers,
+        body: parseJsonOrString(
+          proxyResult.exchange.orchestratorToVictim.response.body,
+        ),
+      },
+    },
+    timestamp: finishedAt - 1,
+  };
+  trace.addAttackStep(outcomeStep);
+
+  const verifyStep: AttackStep = {
+    id: `${req.scenarioId}-verify`,
+    kind: "verify",
+    label: attackSucceeded
+      ? "Attack succeeded against vulnerable endpoint (defense recommendation in panel)"
+      : "Defense correctly rejected the attack request",
+    labelJa: attackSucceeded
+      ? "脆弱エンドポイントに対し攻撃が成立 (防御策はパネル参照)"
+      : "防御が攻撃リクエストを正しく拒否",
+    status: attackSucceeded ? "success" : "blocked",
+    timestamp: finishedAt,
+  };
+  trace.addAttackStep(verifyStep);
+
+  // 7. レスポンス構築 (browserToOrchestrator は orchestrator-exec 自身のフレーム)
+  const browserReqHeaders: Record<string, string> = {};
+  c.req.raw.headers.forEach((v, k) => {
+    browserReqHeaders[k] = v;
+  });
+  const browserToOrchestrator = {
+    request: {
+      line: `POST /api/orchestrator/exec HTTP/1.1`,
+      headers: browserReqHeaders,
+      body: JSON.stringify(json),
+      bytesSent: estimateBytes(JSON.stringify(json)),
+    } satisfies RawHttpRequest,
+    // response は本ハンドラの戻り値 (下記で組み立てた後にメタ的に詰め直す形)
+    response: {
+      line: `HTTP/1.1 200 OK`,
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: null, // 完全な応答は呼び出し側で持つので null とする (永続化しないポリシー)
+      bytesReceived: 0,
+    } satisfies RawHttpResponse,
+  };
+
+  const rawExchange: RawExchange = {
+    browserToOrchestrator,
+    orchestratorToVictim: proxyResult.exchange.orchestratorToVictim,
+    elapsedMs: finishedAt - startedAt,
+  };
+
+  const result: OrchestratorExecResponse = {
+    scenarioId: req.scenarioId,
+    outcome: "succeeded",
+    startedAt,
+    finishedAt,
+    steps: [probeStep, outcomeStep, verifyStep],
+    summary: attackSucceeded
+      ? `Live attack against ${req.target} returned ${victimStatus} — see DataFlowPanel for raw exchange.`
+      : `Live attack request blocked by ${req.target} (HTTP ${victimStatus}).`,
+    summaryJa: attackSucceeded
+      ? `${req.target} への live 攻撃で ${victimStatus} が返却されました。raw exchange は DataFlowPanel を参照。`
+      : `${req.target} が live 攻撃リクエストを拒否しました (HTTP ${victimStatus})。`,
+    rawExchange,
+    mode: "live",
+  };
+
+  return c.json({ success: true, data: result });
+});
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+interface ProxyResult {
+  exchange: {
+    orchestratorToVictim: RawExchange["orchestratorToVictim"];
+  };
+}
+
+async function proxyToVictim(
+  entry: VictimEntry,
+  reqInput: OrchestratorExecRequest["request"],
+  timeoutMs: number,
+): Promise<ProxyResult> {
+  const base = new URL(entry.baseUrl);
+  const isHttps = base.protocol === "https:";
+  const transport = isHttps ? https : http;
+
+  // Host ヘッダ強制上書き (DNS rebinding 予防 — DESIGN/31 §6.3)
+  const forcedHeaders: Record<string, string> = {};
+  for (const [k, v] of Object.entries(reqInput.headers)) {
+    if (k.toLowerCase() === "host") continue; // 破棄
+    forcedHeaders[k] = v;
+  }
+  forcedHeaders["Host"] = base.host;
+  forcedHeaders["Connection"] = "close";
+  if (reqInput.body !== null && reqInput.body !== undefined) {
+    forcedHeaders["Content-Length"] = String(Buffer.byteLength(reqInput.body, "utf8"));
+  }
+
+  return new Promise((resolve, reject) => {
+    const clientReq = transport.request({
+      hostname: base.hostname,
+      port: base.port ? Number(base.port) : isHttps ? 443 : 80,
+      path: reqInput.path,
+      method: reqInput.method,
+      headers: forcedHeaders,
+    });
+
+    clientReq.setTimeout(timeoutMs, () => {
+      clientReq.destroy(new Error("victim_timeout"));
+    });
+
+    const responseChunks: Buffer[] = [];
+    clientReq.on("response", (res) => {
+      res.on("data", (chunk: Buffer) => responseChunks.push(chunk));
+      res.on("end", () => {
+        const rawBody = Buffer.concat(responseChunks);
+        const respHeaders: Record<string, string> = {};
+        for (const [k, v] of Object.entries(res.headers)) {
+          if (typeof v === "string") respHeaders[k] = v;
+          else if (Array.isArray(v)) respHeaders[k] = v.join(", ");
+        }
+        resolve({
+          exchange: {
+            orchestratorToVictim: {
+              request: {
+                line: `${reqInput.method} ${reqInput.path} HTTP/1.1`,
+                headers: forcedHeaders,
+                body: reqInput.body ?? null,
+                bytesSent:
+                  estimateBytes(
+                    `${reqInput.method} ${reqInput.path} HTTP/1.1\r\n` +
+                      headerString(forcedHeaders),
+                  ) + (reqInput.body ? Buffer.byteLength(reqInput.body, "utf8") : 0),
+              },
+              response: {
+                line: `HTTP/1.1 ${res.statusCode ?? 0} ${res.statusMessage ?? ""}`.trim(),
+                status: res.statusCode ?? 0,
+                headers: respHeaders,
+                body: rawBody.toString("utf8"),
+                bytesReceived: rawBody.length,
+              },
+              targetResolvedTo: entry.baseUrl,
+            },
+          },
+        });
+      });
+    });
+
+    clientReq.on("error", (err) => reject(err instanceof Error ? err : new Error(String(err))));
+    if (reqInput.body !== null && reqInput.body !== undefined) {
+      clientReq.write(reqInput.body);
+    }
+    clientReq.end();
+  });
+}
+
+function estimateBytes(s: string): number {
+  return Buffer.byteLength(s, "utf8");
+}
+
+function headerString(headers: Record<string, string>): string {
+  return Object.entries(headers).map(([k, v]) => `${k}: ${v}`).join("\r\n") + "\r\n\r\n";
+}
+
+function parseJsonOrString(s: string | null): unknown {
+  if (s === null || s === "") return s;
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}

--- a/services/attacker-shell/Dockerfile
+++ b/services/attacker-shell/Dockerfile
@@ -1,0 +1,14 @@
+# 教育用 attacker-shell — Phase 2+ で辞書ブルートフォース等のループ実行に使用
+# 関連設計書: DESIGN/30 §2.2, DESIGN/34 §4
+# Phase 1 では起動のみで実機能なし。docker-compose の最小権限設定でコンテナ脱出耐性を実証する。
+FROM alpine:3.20
+LABEL org.opencontainers.image.description="OSI Reference — attacker-shell (educational simulation only)"
+
+RUN apk add --no-cache curl openssl
+
+# 非 root ユーザー
+RUN addgroup -S attacker && adduser -S -G attacker attacker
+USER attacker
+
+# Phase 1 では idle (compose 側で `command: ["sleep", "infinity"]` を期待)
+CMD ["sleep", "infinity"]

--- a/services/attacker-shell/package.json
+++ b/services/attacker-shell/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@osi-ref/attacker-shell",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Docker-only image for educational attack simulation. No npm runtime."
+}

--- a/services/victim-web/Dockerfile
+++ b/services/victim-web/Dockerfile
@@ -1,0 +1,24 @@
+# 教育用脆弱 victim アプリ — services/victim-web
+# 関連設計書: DESIGN/32-victim-web-spec.md §6, DESIGN/34-safety-guardrails-live.md §4
+FROM node:20-alpine
+LABEL org.opencontainers.image.description="OSI Reference — vulnerable victim-web (educational simulation only)"
+
+WORKDIR /app
+
+# npm workspaces を活用: root の package.json + lock + victim-web のみビルド
+COPY package.json package-lock.json* ./
+COPY services/victim-web ./services/victim-web
+
+RUN npm ci --workspace=@osi-ref/victim-web --include-workspace-root=false \
+    && npm run build --workspace=@osi-ref/victim-web
+
+# tmpfs マウントの書き込み先 (compose 側で /app/data に tmpfs を当てる)
+RUN mkdir -p /app/data && chown node:node /app/data
+
+USER node
+EXPOSE 4001
+
+HEALTHCHECK --interval=10s --timeout=2s --retries=3 \
+    CMD wget -q -O- http://localhost:4001/health || exit 1
+
+CMD ["node", "services/victim-web/dist/index.js"]

--- a/services/victim-web/package.json
+++ b/services/victim-web/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@osi-ref/victim-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.19.13",
+    "hono": "^4.12.12",
+    "jsonwebtoken": "^9.0.3"
+  },
+  "devDependencies": {
+    "@types/jsonwebtoken": "^9.0.10"
+  }
+}

--- a/services/victim-web/package.json
+++ b/services/victim-web/package.json
@@ -15,6 +15,9 @@
     "jsonwebtoken": "^9.0.3"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "^9.0.10"
+    "@types/jsonwebtoken": "^9.0.10",
+    "@types/node": "^22.0.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.0"
   }
 }

--- a/services/victim-web/src/index.ts
+++ b/services/victim-web/src/index.ts
@@ -1,0 +1,32 @@
+/**
+ * 脆弱 victim アプリケーション (services/victim-web)
+ *
+ * 【教育目的専用】
+ * このプロセスは OSI 参照アプリの教材機能として、
+ * docker-compose の `victim-net (internal: true)` 内で固定シードデータに対する
+ * 概念実証エンドポイントを提供します。
+ *
+ * - 外部ネットワークへのリクエストは行いません
+ * - 実 CVE のエクスプロイトコードは含みません
+ * - victim-net 外での動作は想定していません
+ *
+ * 関連設計書: DESIGN/04-safety-guardrails.md, DESIGN/32-victim-web-spec.md
+ */
+import { Hono } from "hono";
+import { serve } from "@hono/node-server";
+import { jwtVulnRoutes } from "./routes/jwt-vuln.js";
+
+const app = new Hono();
+
+app.get("/health", (c) =>
+  c.json({ status: "ok", service: "victim-web", time: new Date().toISOString() }),
+);
+
+app.route("/jwt", jwtVulnRoutes);
+
+// PORT は docker container 環境用 (compose で PORT=4001 を渡す)。
+// host で `dev:no-docker` を実行すると vite が PORT=3000 を環境にセットするため、
+// それを避ける目的で VICTIM_PORT を最優先 env に採用する。
+const PORT = Number(process.env.VICTIM_PORT ?? process.env.VICTIM_WEB_PORT ?? 4001);
+console.log(`[victim-web] vulnerable demo server listening on :${PORT}`);
+serve({ fetch: app.fetch, port: PORT });

--- a/services/victim-web/src/routes/jwt-vuln.ts
+++ b/services/victim-web/src/routes/jwt-vuln.ts
@@ -1,0 +1,76 @@
+/**
+ * 脆弱エンドポイント: JWT
+ *
+ * 【教育目的専用】
+ * - victim-net 内のシードデータに対する概念実証のみ
+ * - 実 CVE のエクスプロイトコードは含まない
+ *
+ * 対応 CWE: CWE-345 (alg=none), CWE-347 (signature stripping)
+ * 堅牢実装: server/routes/jwt-ops.ts (algorithms allowlist 必須)
+ * 関連設計書: DESIGN/04-safety-guardrails.md, DESIGN/32-victim-web-spec.md
+ */
+import { Hono } from "hono";
+import jwt from "jsonwebtoken";
+
+// 教材用弱秘密鍵 — victim-web は orchestrator の HS256_SECRET と独立した固定値を持つ
+const WEAK_SECRET = "secret";
+
+export const jwtVulnRoutes = new Hono();
+
+/**
+ * 脆弱: algorithms オプション未指定。
+ * alg=none トークンおよび任意のアルゴリズムが受理される (CWE-345)。
+ *
+ * 期待入力: { "token": "<JWT>" }
+ * 期待挙動: 200 + { valid: true, claims: {...} } を返す (alg=none でも通過)
+ */
+jwtVulnRoutes.post("/verify", async (c) => {
+  let body: { token?: unknown };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ valid: false, error: "Invalid JSON body" }, 400);
+  }
+
+  const token = typeof body.token === "string" ? body.token : null;
+  if (!token) {
+    return c.json({ valid: false, error: "token (string) is required" }, 400);
+  }
+
+  // alg=none を受理する独自実装。jsonwebtoken は { algorithms: ["none"] } を渡しても
+  // 署名なしトークンを受理しない実装になっているため、教育目的で簡略パーサを書く。
+  const segments = token.split(".");
+  if (segments.length === 3) {
+    try {
+      const headerJson = Buffer.from(segments[0], "base64url").toString("utf8");
+      const header = JSON.parse(headerJson) as { alg?: string };
+      if (header.alg === "none" && segments[2] === "") {
+        // 署名検証を完全にスキップ — これが alg=none 脆弱性の本質
+        const payloadJson = Buffer.from(segments[1], "base64url").toString("utf8");
+        const claims = JSON.parse(payloadJson);
+        return c.json({
+          valid: true,
+          claims,
+          algorithm: "none",
+          note: "signature verification skipped (vulnerable: alg=none accepted)",
+        });
+      }
+    } catch {
+      // base64/JSON エラーなら HMAC 経路へフォールバック
+    }
+  }
+
+  // alg=none 以外は弱秘密鍵で HMAC 検証 (algorithms オプション未指定 = 脆弱)
+  try {
+    const decoded = jwt.verify(token, WEAK_SECRET);
+    return c.json({ valid: true, claims: decoded, algorithm: "HS256" });
+  } catch (err) {
+    return c.json(
+      {
+        valid: false,
+        error: err instanceof Error ? err.message : "verification failed",
+      },
+      401,
+    );
+  }
+});

--- a/services/victim-web/tsconfig.json
+++ b/services/victim-web/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -28,6 +28,10 @@ export interface ServerTrace {
   attackSteps?: AttackStep[];
   /** 攻撃デモエンドポイント (/attack/) から発生したトレースの場合 true。middleware が自動セット。 */
   isAttackMode?: boolean;
+  /** "live" = victim コンテナとの実通信 / "narration" = orchestrator 内部シム (DESIGN/31 §4.2) */
+  mode?: "live" | "narration";
+  /** mode: "live" のときに付与。victim 内部の DB/暗号操作が orchestrator から観測不能であることを明示。 */
+  victimNote?: string;
 }
 
 export interface ApiResponse<T = unknown> {
@@ -476,6 +480,120 @@ export interface AttackScenarioMeta {
     /** "vulnerable"=脆弱モード (赤系) / "defensive"=堅牢モード (緑系)。UI スタイルに使用。 */
     kind: "vulnerable" | "defensive";
   }[];
+
+  /**
+   * "live"     : Docker victim コンテナと実通信 → POST /api/orchestrator/exec
+   * "narration": orchestrator 内部シム → POST /api/<area>/attack/<scenario-id>
+   * 未指定時は "narration" として扱う (Phase 1 移行期間の後方互換)。
+   */
+  mode?: "live" | "narration";
+
+  /**
+   * mode: "live" シナリオで RawHttpComposer の初期値として使うテンプレート。
+   * 学習者は target の dropdown と headers/body を編集してから送信する。
+   */
+  liveTemplate?: {
+    target: VictimTarget;
+    method: HttpMethod;
+    path: string;
+    headers?: Record<string, string>;
+    body?: string;
+  };
+}
+
+/* ── Live Attack: Orchestrator API (DESIGN/31) ── */
+
+/**
+ * VICTIM_ALLOWLIST のキー文字列リテラル union。
+ * ブラウザは `target` フィールドにこのキーのみ送信できる (URL 偽造防止)。
+ * orchestrator が allowlist から baseUrl を解決する。
+ */
+export type VictimTarget =
+  | "victim-web"
+  | "attacker-shell"
+  | "victim-tls-proxy"
+  | "victim-saml-idp";
+
+/**
+ * VICTIM_ALLOWLIST の値エントリ。
+ * baseUrl の上書きは禁止 (環境変数も含む)。Phase ガードに利用される `phaseAvailable` を持つ。
+ */
+export interface VictimEntry {
+  /**
+   * 転送先 URL。`http://` または `https://` で始まる完全 URL。
+   * `exec://<container-name>` で始まる場合は docker exec 経由のコマンド実行を示す (Phase 2+ の attacker-shell 用)。
+   */
+  baseUrl: string;
+  /** この victim が接続する Docker ネットワーク名。 */
+  network: "victim-net";
+  /** この victim が利用可能になる最初の Phase 番号。 */
+  phaseAvailable: 1 | 2 | 3 | 4 | 5;
+}
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "HEAD" | "OPTIONS";
+
+/** 学習者が RawHttpComposer で組み立てたリクエストのフロント送信フォーマット。 */
+export interface OrchestratorExecRequest {
+  /** AttackScenarioMeta.id と一致させる。例: "jwt-alg-none" */
+  scenarioId: string;
+  /** VICTIM_ALLOWLIST のキー文字列。baseUrl は orchestrator が allowlist から取得する。 */
+  target: VictimTarget;
+  request: {
+    method: HttpMethod;
+    /** pathname + query string。"/" で始まる必要がある。 */
+    path: string;
+    headers: Record<string, string>;
+    body?: string | null;
+  };
+  /** victim コンテナへの接続タイムアウト (ms)。100–10000、デフォルト 3000。 */
+  timeoutMs?: number;
+}
+
+export interface RawHttpRequest {
+  /** "POST /jwt/verify HTTP/1.1" 形式のリクエスト行 */
+  line: string;
+  headers: Record<string, string>;
+  body: string | null;
+  /** 送信した総バイト数 (ヘッダ + ボディ) */
+  bytesSent: number;
+}
+
+export interface RawHttpResponse {
+  /** "HTTP/1.1 200 OK" 形式のステータス行 */
+  line: string;
+  status: number;
+  headers: Record<string, string>;
+  body: string | null;
+  /** 受信した総バイト数 (ヘッダ + ボディ) */
+  bytesReceived: number;
+}
+
+/**
+ * 双方向 raw HTTP キャプチャ。browser⇄orchestrator + orchestrator⇄victim の両ペア。
+ * メモリ上のみ保持し、attack_log には summary のみを書き込む (DESIGN/31 §6.4)。
+ */
+export interface RawExchange {
+  browserToOrchestrator: {
+    request: RawHttpRequest;
+    response: RawHttpResponse;
+  };
+  orchestratorToVictim: {
+    request: RawHttpRequest;
+    response: RawHttpResponse;
+    /** VICTIM_ALLOWLIST から解決された baseUrl */
+    targetResolvedTo: string;
+  };
+  /** browser → orchestrator → victim → orchestrator → browser の総経過 (ms) */
+  elapsedMs: number;
+}
+
+/**
+ * POST /api/orchestrator/exec の成功レスポンス型。
+ * AttackResult に live モード固有フィールドを追加する。
+ */
+export interface OrchestratorExecResponse extends AttackResult {
+  rawExchange: RawExchange;
+  mode: "live";
 }
 
 /** attack_log テーブルの行型。 */

--- a/src/components/auth/JwtInspector.tsx
+++ b/src/components/auth/JwtInspector.tsx
@@ -9,7 +9,7 @@ import ViewModeToggle from "../shared/ViewModeToggle";
 import AttackPanel from "../shared/AttackPanel";
 import { getViewMode } from "../../state/attack-state";
 import { jwtScenarios } from "./attacks/scenarios/jwt-scenarios";
-import type { AttackResult } from "../../../shared/api-types";
+import type { AttackResult, OrchestratorExecResponse } from "../../../shared/api-types";
 import "./JwtInspector.css";
 
 const SCOPE = "jwt-ops";
@@ -332,6 +332,7 @@ export default function JwtInspector() {
         <AttackPanel
           tabId="jwt"
           scenarios={jwtScenarios}
+          allowedTargets={["victim-web"]}
           onRunScenario={async (s) => {
             const suffix = s.id.replace(/^jwt-/, "");
             // E-2: 両モード並列実行のため body は不要 (空オブジェクト)
@@ -349,6 +350,46 @@ export default function JwtInspector() {
                 steps: [],
                 summaryJa: res.error ?? "実行エラーが発生しました",
                 summary: res.error ?? "Execution error occurred",
+              };
+            }
+            return res.data;
+          }}
+          onRunLiveScenario={async (s, payload) => {
+            const res = await apiPost<OrchestratorExecResponse>(
+              "/api/orchestrator/exec",
+              {
+                scenarioId: s.id,
+                target: payload.target,
+                request: payload.request,
+              },
+              "attack-jwt"
+            );
+            if (!res.data) {
+              const errMsg = res.error ?? "Execution error";
+              const friendlyJa =
+                errMsg === "victim_unreachable"
+                  ? "victim-web が起動していません。docker compose up -d victim-web または npm run dev:victim を実行してください。"
+                  : errMsg === "live_attack_disabled_in_production"
+                  ? "live モードは production 環境では無効です。"
+                  : errMsg === "phase_not_reached"
+                  ? "このシナリオは現在の Phase ではまだ live 化されていません。"
+                  : `実行エラー: ${errMsg}`;
+              const friendlyEn =
+                errMsg === "victim_unreachable"
+                  ? "victim-web is not reachable. Start it with `docker compose up -d victim-web` or `npm run dev:victim`."
+                  : errMsg === "live_attack_disabled_in_production"
+                  ? "Live mode is disabled in production."
+                  : errMsg === "phase_not_reached"
+                  ? "This scenario is not yet live in the current phase."
+                  : `Execution error: ${errMsg}`;
+              return {
+                scenarioId: s.id,
+                outcome: "error" as const,
+                startedAt: Date.now(),
+                finishedAt: Date.now(),
+                steps: [],
+                summaryJa: friendlyJa,
+                summary: friendlyEn,
               };
             }
             return res.data;

--- a/src/components/auth/attacks/scenarios/jwt-scenarios.ts
+++ b/src/components/auth/attacks/scenarios/jwt-scenarios.ts
@@ -54,6 +54,18 @@ const decoded = jwt.verify(token, secret);  // 危険`,
         kind: "defensive",
       },
     ],
+    // Phase 1 PoC: live attack 化された最初のシナリオ。
+    // RawHttpComposer に下記テンプレートが初期表示され、学習者が自ら body を編集して送信する。
+    mode: "live",
+    liveTemplate: {
+      target: "victim-web",
+      method: "POST",
+      path: "/jwt/verify",
+      headers: { "Content-Type": "application/json" },
+      // alg=none + 空署名の偽造 JWT。学習者は body を編集してこれを差し替えても良い。
+      // header: {"alg":"none","typ":"JWT"}, payload: {"sub":"seed_alice","role":"admin"}
+      body: '{\n  "token": "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJzZWVkX2FsaWNlIiwicm9sZSI6ImFkbWluIn0."\n}',
+    },
   },
   {
     id: "jwt-weak-secret-bruteforce",

--- a/src/components/shared/AttackPanel.css
+++ b/src/components/shared/AttackPanel.css
@@ -99,3 +99,13 @@
   outline: 2px solid var(--glow-color);
   outline-offset: 2px;
 }
+
+.attack-error-toast {
+  background: var(--color-danger-dim, rgba(255, 77, 79, 0.15));
+  color: var(--color-danger, #ff4d4f);
+  border: 1px solid var(--color-danger-border, rgba(255, 77, 79, 0.3));
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  padding: 8px 12px;
+}

--- a/src/components/shared/AttackPanel.tsx
+++ b/src/components/shared/AttackPanel.tsx
@@ -1,6 +1,11 @@
 import { createSignal, createEffect, Show, For } from "solid-js";
 import { useI18n } from "../../i18n/context";
-import type { AttackScenarioMeta, AttackResult } from "../../../shared/api-types";
+import type {
+  AttackScenarioMeta,
+  AttackResult,
+  OrchestratorExecRequest,
+  VictimTarget,
+} from "../../../shared/api-types";
 import type { AuthSubView } from "../../types/security";
 import EducationalWarningBanner from "./EducationalWarningBanner";
 import AttackScenarioSelector from "./AttackScenarioSelector";
@@ -8,6 +13,7 @@ import AttackStepTimeline from "./AttackStepTimeline";
 import AttackResultBanner from "./AttackResultBanner";
 import AttackDefensePanel from "./AttackDefensePanel";
 import DataFlowPanel from "./DataFlowPanel";
+import RawHttpComposer from "./RawHttpComposer";
 import "./AttackPanel.css";
 
 interface AttackPanelProps {
@@ -18,6 +24,16 @@ interface AttackPanelProps {
    * 排他選択モードは廃止されたため、modeBody 引数は不要。
    */
   onRunScenario: (scenario: AttackScenarioMeta) => Promise<AttackResult>;
+  /**
+   * mode: "live" シナリオで RawHttpComposer の SEND 押下時に呼ばれる。
+   * 未指定時は live シナリオを narration にフォールバックさせる (PR-1 後方互換)。
+   */
+  onRunLiveScenario?: (
+    scenario: AttackScenarioMeta,
+    payload: { target: VictimTarget; request: OrchestratorExecRequest["request"] },
+  ) => Promise<AttackResult>;
+  /** Phase 1 では victim-web のみ。Phase 4+ で複数 target を表示する。 */
+  allowedTargets?: VictimTarget[];
 }
 
 function AttackPanel(props: AttackPanelProps) {
@@ -29,9 +45,14 @@ function AttackPanel(props: AttackPanelProps) {
   const [attackResult, setAttackResult] = createSignal<AttackResult | null>(null);
   const [running, setRunning] = createSignal(false);
   const [defenseOpen, setDefenseOpen] = createSignal(false);
+  const [errorMessage, setErrorMessage] = createSignal<string | null>(null);
 
   const selectedScenario = () =>
     props.scenarios.find((s) => s.id === selectedId()) ?? props.scenarios[0] ?? null;
+
+  const isLiveMode = () => selectedScenario()?.mode === "live";
+  const allowedTargets = (): VictimTarget[] =>
+    props.allowedTargets ?? ["victim-web"];
 
   /* scenarios が変化したとき selectedId が無効/空なら最初のシナリオに同期 */
   createEffect(() => {
@@ -50,15 +71,44 @@ function AttackPanel(props: AttackPanelProps) {
     }
   });
 
+  /* シナリオ切替時に直前の結果・エラーをクリア */
+  createEffect(() => {
+    selectedId();
+    setAttackResult(null);
+    setErrorMessage(null);
+  });
+
   async function handleRunAttack() {
     const scenario = selectedScenario();
     if (!scenario || running()) return;
     setRunning(true);
     setAttackResult(null);
     setDefenseOpen(false);
+    setErrorMessage(null);
     try {
       const result = await props.onRunScenario(scenario);
       setAttackResult(result);
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  async function handleSendLive(payload: {
+    target: VictimTarget;
+    request: OrchestratorExecRequest["request"];
+  }) {
+    const scenario = selectedScenario();
+    if (!scenario || running() || !props.onRunLiveScenario) return;
+    setRunning(true);
+    setAttackResult(null);
+    setDefenseOpen(false);
+    setErrorMessage(null);
+    try {
+      const result = await props.onRunLiveScenario(scenario, payload);
+      setAttackResult(result);
+      if (result.outcome === "error") {
+        setErrorMessage(result.summaryJa ?? result.summary ?? t("実行エラー", "Execution error"));
+      }
     } finally {
       setRunning(false);
     }
@@ -97,17 +147,42 @@ function AttackPanel(props: AttackPanelProps) {
           </div>
         </Show>
 
-        {/* 4. 実行ボタン */}
-        <button
-          class="attack-run-button"
-          disabled={running() || props.scenarios.length === 0}
-          aria-busy={running()}
-          onClick={handleRunAttack}
-        >
-          <Show when={running()} fallback={t("攻撃を実行", "Run Attack")}>
-            {t("実行中...", "Running...")}
-          </Show>
-        </button>
+        {/* 4a. live モード: RawHttpComposer */}
+        <Show when={isLiveMode() && selectedScenario()?.liveTemplate && props.onRunLiveScenario}>
+          <RawHttpComposer
+            scenarioId={selectedScenario()!.id}
+            allowedTargets={allowedTargets()}
+            template={{
+              target: selectedScenario()!.liveTemplate!.target,
+              method: selectedScenario()!.liveTemplate!.method,
+              path: selectedScenario()!.liveTemplate!.path,
+              headers: selectedScenario()!.liveTemplate!.headers ?? {},
+              body: selectedScenario()!.liveTemplate!.body ?? "",
+            }}
+            sending={running()}
+            onSend={handleSendLive}
+          />
+        </Show>
+
+        {/* 4b. narration モード: 既存実行ボタン */}
+        <Show when={!isLiveMode()}>
+          <button
+            class="attack-run-button"
+            disabled={running() || props.scenarios.length === 0}
+            aria-busy={running()}
+            onClick={handleRunAttack}
+          >
+            <Show when={running()} fallback={t("攻撃を実行", "Run Attack")}>
+              {t("実行中...", "Running...")}
+            </Show>
+          </button>
+        </Show>
+
+        <Show when={errorMessage() !== null}>
+          <div class="attack-error-toast" role="alert" aria-live="assertive">
+            {errorMessage()}
+          </div>
+        </Show>
 
         <div class="attack-panel-body">
           {/* 5. タイムライン */}

--- a/src/components/shared/RawHttpComposer.css
+++ b/src/components/shared/RawHttpComposer.css
@@ -1,0 +1,189 @@
+.raw-http-composer {
+  position: relative;
+  border: 1px solid var(--color-attack-accent);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  padding: 1rem 1rem 0.85rem;
+  margin: 0.75rem 0;
+}
+
+.raw-http-composer-live-badge {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  background: var(--color-attack-bg);
+  color: var(--color-attack-accent);
+  border: 1px solid var(--color-attack-accent);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 2px 6px;
+  letter-spacing: 0.08em;
+}
+
+.raw-http-composer-topbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem 0.5rem;
+  margin-bottom: 0.75rem;
+  padding-right: 3.5rem; /* avoid LIVE badge */
+}
+
+.rhc-label {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.rhc-select,
+.rhc-input {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 4px 6px;
+}
+
+.rhc-input:focus,
+.rhc-select:focus {
+  outline: 2px solid var(--color-attack-accent);
+  outline-offset: 1px;
+}
+
+.rhc-input:disabled,
+.rhc-select:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.rhc-path {
+  flex: 1 1 200px;
+  min-width: 160px;
+}
+
+.raw-http-composer-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: 0.5rem;
+}
+
+.rhc-tab {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  padding: 6px 12px;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+
+.rhc-tab[data-active="true"] {
+  color: var(--color-attack-accent);
+  border-bottom-color: var(--color-attack-accent);
+}
+
+.raw-http-composer-tabpanel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.rhc-header-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.rhc-header-row-disabled {
+  opacity: 0.7;
+}
+
+.rhc-header-key {
+  flex: 0 1 30%;
+  min-width: 110px;
+}
+
+.rhc-header-value {
+  flex: 1 1 auto;
+}
+
+.rhc-header-remove {
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  cursor: pointer;
+  width: 1.6rem;
+  height: 1.6rem;
+  line-height: 1;
+}
+
+.rhc-header-remove:hover {
+  color: var(--color-attack-accent);
+  border-color: var(--color-attack-accent);
+}
+
+.rhc-header-add {
+  align-self: flex-start;
+  background: transparent;
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.rhc-header-add:hover {
+  color: var(--color-attack-accent);
+  border-color: var(--color-attack-accent);
+}
+
+.rhc-body {
+  width: 100%;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 6px;
+  resize: vertical;
+}
+
+.rhc-body:focus {
+  outline: 2px solid var(--color-attack-accent);
+  outline-offset: 1px;
+}
+
+.rhc-send {
+  align-self: flex-start;
+  background: var(--color-attack-accent);
+  color: #0a1628;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 6px 16px;
+  cursor: pointer;
+  transition: transform var(--transition-fast);
+  letter-spacing: 0.05em;
+}
+
+.rhc-send:hover:not(:disabled) {
+  transform: scale(1.02);
+}
+
+.rhc-send:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}

--- a/src/components/shared/RawHttpComposer.tsx
+++ b/src/components/shared/RawHttpComposer.tsx
@@ -1,0 +1,257 @@
+import { createSignal, Show, For } from "solid-js";
+import { useI18n } from "../../i18n/context";
+import type {
+  HttpMethod,
+  OrchestratorExecRequest,
+  VictimTarget,
+} from "../../../shared/api-types";
+import "./RawHttpComposer.css";
+
+/**
+ * Live attack request composer.
+ *
+ * 学習者がブラウザから生 HTTP リクエストを組み立てて
+ * `POST /api/orchestrator/exec` に送る入力 UI。
+ * Host ヘッダは orchestrator が強制上書きするため編集不可。
+ *
+ * Phase 1 minimal: Headers タブ + Body タブのみ実装、Raw タブと SequenceDiagramView は PR-2 に分離。
+ *
+ * 関連設計書: DESIGN/33-raw-http-composer.md, DESIGN/34-safety-guardrails-live.md
+ */
+
+interface RawHttpComposerProps {
+  scenarioId: string;
+  /** orchestrator 側の VICTIM_ALLOWLIST と同期した利用可能 target */
+  allowedTargets: VictimTarget[];
+  /** 初期テンプレート (シナリオごとの推奨開始値) */
+  template: {
+    target: VictimTarget;
+    method: HttpMethod;
+    path: string;
+    headers: Record<string, string>;
+    body: string;
+  };
+  /** SEND ボタン押下で呼ばれる。AttackPanel が orchestrator/exec を叩く。 */
+  onSend: (
+    payload: { target: VictimTarget; request: OrchestratorExecRequest["request"] },
+  ) => Promise<void>;
+  /** AttackPanel が「実行中」状態を伝播する */
+  sending: boolean;
+}
+
+type HeaderEntry = { key: string; value: string };
+
+const HTTP_METHODS: HttpMethod[] = ["GET", "POST", "PUT", "PATCH", "DELETE"];
+
+function RawHttpComposer(props: RawHttpComposerProps) {
+  const { t } = useI18n();
+
+  const [target, setTarget] = createSignal<VictimTarget>(props.template.target);
+  const [method, setMethod] = createSignal<HttpMethod>(props.template.method);
+  const [path, setPath] = createSignal<string>(props.template.path);
+  const [headers, setHeaders] = createSignal<HeaderEntry[]>(
+    Object.entries(props.template.headers)
+      .filter(([k]) => k.toLowerCase() !== "host")
+      .map(([key, value]) => ({ key, value })),
+  );
+  const [body, setBody] = createSignal<string>(props.template.body);
+  const [activeTab, setActiveTab] = createSignal<"headers" | "body">("body");
+
+  function updateHeader(idx: number, patch: Partial<HeaderEntry>) {
+    setHeaders((prev) =>
+      prev.map((h, i) => (i === idx ? { ...h, ...patch } : h)),
+    );
+  }
+  function removeHeader(idx: number) {
+    setHeaders((prev) => prev.filter((_, i) => i !== idx));
+  }
+  function addHeader() {
+    setHeaders((prev) => [...prev, { key: "", value: "" }]);
+  }
+
+  async function handleSend() {
+    if (props.sending) return;
+    const headerObj: Record<string, string> = {};
+    for (const h of headers()) {
+      const k = h.key.trim();
+      if (k && k.toLowerCase() !== "host") headerObj[k] = h.value;
+    }
+    await props.onSend({
+      target: target(),
+      request: {
+        method: method(),
+        path: path(),
+        headers: headerObj,
+        body: body() || null,
+      },
+    });
+  }
+
+  return (
+    <div
+      class="raw-http-composer"
+      data-scenario-id={props.scenarioId}
+      role="region"
+      aria-label={t("生 HTTP リクエスト編集", "Raw HTTP request composer")}
+    >
+      <span
+        class="raw-http-composer-live-badge"
+        aria-label={t("LIVE 攻撃モード", "LIVE attack mode")}
+      >
+        LIVE
+      </span>
+
+      <div class="raw-http-composer-topbar">
+        <label class="rhc-label" for={`rhc-target-${props.scenarioId}`}>
+          {t("送信先", "Target")}
+        </label>
+        <select
+          id={`rhc-target-${props.scenarioId}`}
+          class="rhc-select"
+          value={target()}
+          onChange={(e) => setTarget(e.currentTarget.value as VictimTarget)}
+          aria-label={t("攻撃対象 victim を選択", "Select attack target")}
+        >
+          <For each={props.allowedTargets}>
+            {(tgt) => <option value={tgt}>{tgt}</option>}
+          </For>
+        </select>
+
+        <label class="rhc-label" for={`rhc-method-${props.scenarioId}`}>
+          {t("メソッド", "Method")}
+        </label>
+        <select
+          id={`rhc-method-${props.scenarioId}`}
+          class="rhc-select"
+          value={method()}
+          onChange={(e) => setMethod(e.currentTarget.value as HttpMethod)}
+        >
+          <For each={HTTP_METHODS}>
+            {(m) => <option value={m}>{m}</option>}
+          </For>
+        </select>
+
+        <label class="rhc-label" for={`rhc-path-${props.scenarioId}`}>
+          {t("パス", "Path")}
+        </label>
+        <input
+          id={`rhc-path-${props.scenarioId}`}
+          class="rhc-input rhc-path"
+          type="text"
+          value={path()}
+          onInput={(e) => setPath(e.currentTarget.value)}
+          spellcheck={false}
+        />
+      </div>
+
+      <div class="raw-http-composer-tabs" role="tablist">
+        <button
+          type="button"
+          class="rhc-tab"
+          role="tab"
+          aria-selected={activeTab() === "headers"}
+          data-active={activeTab() === "headers"}
+          onClick={() => setActiveTab("headers")}
+        >
+          {t("ヘッダー", "Headers")}
+        </button>
+        <button
+          type="button"
+          class="rhc-tab"
+          role="tab"
+          aria-selected={activeTab() === "body"}
+          data-active={activeTab() === "body"}
+          onClick={() => setActiveTab("body")}
+        >
+          {t("ボディ", "Body")}
+        </button>
+      </div>
+
+      <div class="raw-http-composer-tabpanel" role="tabpanel">
+        <Show when={activeTab() === "headers"}>
+          <div class="rhc-header-row rhc-header-row-disabled">
+            <input
+              class="rhc-input rhc-header-key"
+              value="Host"
+              disabled
+              aria-label="Host header (orchestrator-managed)"
+            />
+            <input
+              class="rhc-input rhc-header-value"
+              value={t(
+                "(orchestrator が強制設定)",
+                "(set by orchestrator)",
+              )}
+              disabled
+            />
+          </div>
+          <For each={headers()}>
+            {(h, idx) => (
+              <div class="rhc-header-row">
+                <input
+                  class="rhc-input rhc-header-key"
+                  type="text"
+                  placeholder="Header-Name"
+                  value={h.key}
+                  onInput={(e) => updateHeader(idx(), { key: e.currentTarget.value })}
+                  spellcheck={false}
+                />
+                <input
+                  class="rhc-input rhc-header-value"
+                  type="text"
+                  placeholder="value"
+                  value={h.value}
+                  onInput={(e) => updateHeader(idx(), { value: e.currentTarget.value })}
+                  spellcheck={false}
+                />
+                <button
+                  type="button"
+                  class="rhc-header-remove"
+                  onClick={() => removeHeader(idx())}
+                  aria-label={t("ヘッダ削除", "Remove header")}
+                >
+                  ×
+                </button>
+              </div>
+            )}
+          </For>
+          <button type="button" class="rhc-header-add" onClick={addHeader}>
+            {t("+ ヘッダを追加", "+ Add header")}
+          </button>
+        </Show>
+
+        <Show when={activeTab() === "body"}>
+          <textarea
+            class="rhc-body"
+            value={body()}
+            onInput={(e) => setBody(e.currentTarget.value)}
+            rows={8}
+            spellcheck={false}
+            aria-label={t("リクエストボディ", "Request body")}
+            placeholder={t(
+              '例: {"token":"<偽造 JWT>"}',
+              'e.g. {"token":"<forged JWT>"}',
+            )}
+          />
+        </Show>
+      </div>
+
+      <button
+        type="button"
+        class="rhc-send"
+        disabled={props.sending}
+        aria-busy={props.sending}
+        onClick={handleSend}
+      >
+        <Show
+          when={props.sending}
+          fallback={t("送信 (LIVE)", "Send Attack (LIVE)")}
+        >
+          {t("送信中…", "Sending…")}
+        </Show>
+      </button>
+    </div>
+  );
+}
+
+export default RawHttpComposer;


### PR DESCRIPTION
## Summary

DESIGN/30-34 を実装に落とし、ブラウザ → orchestrator → victim-web の 3 段 e2e フローを `jwt-alg-none` で貫通させた **PR-1 (e2e-first)**。後続 PR-2 で `SequenceDiagramView` と完成度の高い UI / バッジ群を追加。

- **Infra**: npm workspaces (`services/*`)、`docker-compose.yml` (`victim-net: internal: true`, tmpfs/cap_drop/read_only)、`services/victim-web/` (脆弱 Hono)、`services/attacker-shell/` (Phase 2+ 最小権限スケルトン)
- **Orchestrator**: `POST /api/orchestrator/exec` zod + `VICTIM_ALLOWLIST` + Phase ガード + Production guard + `Host` 強制上書き + 双方向 raw bytes キャプチャ + `_trace.mode:"live"` / `victimNote`
- **Frontend (minimal)**: `RawHttpComposer.tsx` (target/method/path/headers/body + LIVE バッジ、export/copy/persist 全無し)、`AttackPanel.tsx` の `isLiveMode()` 排他分岐、`jwt-alg-none` を `mode: "live"` 化
- **DX**: `dev:no-docker` フォールバック維持 (concurrently で vite + server + victim-web の host 三並列、`dev:victim` で単独起動可)
- **Docs**: CLAUDE.md に DESIGN ⇄ 実装 対応表 (Component Mapping) を追記

## Verification

- ✅ `curl POST /api/orchestrator/exec` → victim-web 200 + `rawExchange.{browserToOrchestrator,orchestratorToVictim}` 両方キャプチャ + `_trace.mode:\"live\"` 付与
- ✅ Browser UI: \`Attacker mode\` → \`alg=none 攻撃\` → SEND ボタン → 3 ステップ (probe/exploit/verify) 表示 + AttackDefensePanel 自動展開
- ✅ Regression: \`jwt-weak-secret-bruteforce\` 等の narration シナリオは既存 \"攻撃を実行\" ボタン経由で動作 (RawHttpComposer は表示されない)
- ✅ Host header forced override: orchestrator が browser 送信の \`Host\` を破棄し \`localhost:4001\` (allowlist 由来) に書き換える
- ✅ Phase guard: \`attacker-shell\` (\`phaseAvailable: 2\`) を target に指定 → 503 \`exec_target_not_implemented\`

## Out of scope (PR-2 で追加予定)

- \`SequenceDiagramView\` (D3 ベース 3 アクタースイムレーン)
- \`DataFlowPanel\` の Sequence タブ
- \`EducationalWarningBanner\` / \`AttackScenarioSelector\` の LIVE/NARRATION バッジ
- \`AttackStepTimeline\` の live モード強化 (rawExchange からの派生)
- GitHub Actions Docker 化
- \`server/__tests__/orchestrator-live.test.ts\`
- PR テンプレート (\`.github/pull_request_template.md\`)

## Test plan

- [ ] \`npm install\` で workspaces (\`services/*\`) が hoisting される
- [ ] \`npm run dev:no-docker\` で vite (3000) / server (3001) / victim-web (4001) の 3 プロセスが立ち上がる
- [ ] \`curl http://localhost:4001/health\` が 200 を返す
- [ ] \`/auth/jwt\` → \`Attacker mode\` → \`alg=none 攻撃\` で RawHttpComposer の LIVE バッジが見える
- [ ] SEND 押下で 3 ステップ表示 + 防御パネル展開
- [ ] 別シナリオ (例: \`jwt-weak-secret-bruteforce\`) で既存 narration UI が壊れていない
- [ ] (Docker 利用可能環境) \`docker compose up -d victim-web\` + \`npm run dev\` で同等動作
- [ ] \`docker network inspect osi-reference_victim-net\` で \`Internal: true\` 確認

## Refs

- Umbrella: #7
- Phase 1 issue: #8
- DESIGN: \`DESIGN/30-live-attack-architecture.md\`, \`DESIGN/31-orchestrator-spec.md\`, \`DESIGN/32-victim-web-spec.md\`, \`DESIGN/33-raw-http-composer.md\`, \`DESIGN/34-safety-guardrails-live.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)