### PR TITLE
feat: live attack Phase 1 PR-2 — UI 完成度 (SequenceDiagramView + LIVE バッジ + Raw タブ)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,82 @@
+<!--
+osi-reference PR テンプレート
+- live モードを含まない PR でもチェックリストは残してください (各項目は N/A 可)。
+- DESIGN/34 §6 由来の live モード PR チェックリストを最後に含みます。
+-->
+
+## 概要 / Summary
+
+<!-- 1-3 行で「何を」「なぜ」変更したか。 -->
+
+## 関連 Issue / Linked issues
+
+- closes #
+- refs #
+
+## 変更点 / Changes
+
+<!-- ファイル単位ではなく、機能単位で箇条書きにしてください。 -->
+
+-
+
+## スクリーンショット (UI 変更時) / Screenshots
+
+<!-- 認証タブ、攻撃パネル、SequenceDiagramView など UI に触れる場合は前後の差分を貼ってください。 -->
+
+## テスト方法 / How to test
+
+- [ ] `npm run dev` (もしくは `npm run dev:no-docker`) でフロント:3000 + バックエンド:3001 を起動
+- [ ] `curl http://localhost:3001/api/health` が `{"status":"ok"}` を返す
+- [ ] 影響範囲のタブで正常系デモが動作する
+- [ ] 影響範囲のタブで攻撃シナリオが期待どおり成功 / 防御される
+
+## DESIGN ⇄ 実装 整合性 / Design ↔ Implementation alignment
+
+- [ ] 関連 DESIGN/*.md を読み、本 PR が逸脱していないことを確認した
+- [ ] 仕様変更を含む場合は対応 DESIGN/*.md を更新した
+- [ ] CLAUDE.md の「DESIGN ⇄ 実装 対応表」に新規ファイルを追加した (新規ファイルがある場合のみ)
+
+---
+
+## live モード PR チェックリスト / Live-mode PR checklist
+
+> このセクションは `AttackScenarioMeta.mode === "live"` のシナリオを追加 / 変更する PR、
+> または `services/victim-web/`・`server/routes/orchestrator-exec.ts`・`docker-compose.yml`・
+> `RawHttpComposer` / `SequenceDiagramView` のいずれかに変更がある PR で記入する。
+> 該当しない PR は `N/A` と記入してチェックリストごとスキップして構わない。
+>
+> 出典: [DESIGN/34 §3, §6](../DESIGN/34-safety-guardrails-live.md)
+
+### DESIGN/34 §3 チェックリスト / Safety guardrails
+
+- [ ] §3.1 隔離チェック (差分) — 全項目を確認した
+- [ ] §3.2 表示・文言チェック (差分) — 全項目を確認した
+- [ ] §3.3 教育内容チェック (差分) — 全項目を確認した
+- [ ] §3.4 ペイロードチェック (差分) — 全項目を確認した
+- [ ] §3.5 ログ・デバッグチェック (差分) — 全項目を確認した
+
+### victim-web 変更時の追加確認 / victim-web changes
+
+- [ ] `services/victim-web/` の変更で堅牢実装の参照リンクが `AttackDefensePanel` から表示できる
+- [ ] `docker compose ps` で victim コンテナの PORTS 列が空 (ホストへの公開なし)
+- [ ] (Phase 3+) `docker network inspect victim-net` の `"Internal"` が `true`
+- [ ] (Phase 1-2 暫定) `internal: true` を無効化したまま運用する根拠を PR 本文に記載
+
+### Docker 環境確認 / Docker environment
+
+- [ ] `docker compose up -d` 後に全コンテナが `healthy` になる
+- [ ] (Phase 3+) `npm run dev:no-docker` 廃止後の動作確認方法を PR 本文に記載
+
+### live UI 確認 / Live attack UI
+
+- [ ] `EducationalWarningBanner` の `LIVE` バッジが live シナリオ選択時のみ表示される
+- [ ] `AttackScenarioSelector` の各シナリオに `LIVE` / `NARRATION` バッジが付く
+- [ ] `RawHttpComposer` の Host ヘッダ入力欄が編集不可 (`disabled`) になっている
+- [ ] `RawHttpComposer` に export / copy / persist 系ボタンが追加されていない
+- [ ] `DataFlowPanel` の `Sequence` タブが live シナリオ選択時のみ露出する
+- [ ] `SequenceDiagramView` の矢印クリックで raw bytes ポップアップが開く
+- [ ] `localStorage` / `sessionStorage` への書き込みが追加されていない
+
+### DESIGN/04 既存チェックリスト
+
+- [ ] §4.1〜4.5 の全項目 (`DESIGN/04-safety-guardrails.md` を参照)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,10 +167,12 @@ PR レビュー時の「仕様 ↔ 実装」往復に使う。Phase 2+ で新規
 | DESIGN/32 §2 (services/victim-web 構造) | `services/victim-web/{package.json,tsconfig.json,Dockerfile,src/index.ts,src/routes/jwt-vuln.ts}` | 脆弱 victim アプリ |
 | DESIGN/32 §4.1 (JWT 脆弱エンドポイント) | `services/victim-web/src/routes/jwt-vuln.ts` | `POST /jwt/verify` (alg=none 受理) |
 | DESIGN/32 §6 (Dockerfile + compose 安全設定) | `services/victim-web/Dockerfile`, `docker-compose.yml` (victim-web セクション) | tmpfs / cap_drop / read_only |
-| DESIGN/33 §2 (RawHttpComposer) | `src/components/shared/RawHttpComposer.tsx`, `RawHttpComposer.css` | 生 HTTP リクエスト編集 UI |
-| DESIGN/33 §3 (SequenceDiagramView) | **PR-2 で追加予定** | D3 シーケンス図 |
-| DESIGN/33 §4 (AttackPanel 統合) | `src/components/shared/AttackPanel.tsx` (`isLiveMode()`, `onRunLiveScenario`) | 排他 `<Show>` |
-| DESIGN/33 §5 (mode バッジ) | `RawHttpComposer.tsx` の `.raw-http-composer-live-badge` のみ実装。`EducationalWarningBanner` / `AttackScenarioSelector` バッジは **PR-2 で追加予定** | LIVE/NARRATION 表示 |
+| DESIGN/33 §2 (RawHttpComposer) | `src/components/shared/RawHttpComposer.tsx`, `RawHttpComposer.css` (Headers / Body / Raw タブ) | 生 HTTP リクエスト編集 UI |
+| DESIGN/33 §3 (SequenceDiagramView) | `src/components/shared/SequenceDiagramView.tsx`, `SequenceDiagramView.css` | D3 SVG シーケンス図 + raw bytes ポップアップ |
+| DESIGN/33 §4 (AttackPanel 統合) | `src/components/shared/AttackPanel.tsx` (`isLiveMode()`, `onRunLiveScenario`, `rawExchange` Signal), `DataFlowPanel.tsx` (Sequence タブ + `isLiveMode` / `rawExchange` props) | 排他 `<Show>` + Sequence タブ |
+| DESIGN/33 §4.1 (AttackStepTimeline live 派生) | (実装なし) | **PR-1 後 obsolete**: orchestrator が live 経路でも 3 段 AttackStep を返すため不要。raw bytes は SequenceDiagramView 担当。 |
+| DESIGN/33 §5 (mode バッジ) | `RawHttpComposer.tsx` `.raw-http-composer-live-badge`, `EducationalWarningBanner.tsx` (`mode` prop + `.edu-warning-live-badge`), `AttackScenarioSelector.tsx` (`ModeBadge` + `.scenario-mode-badge`) | LIVE/NARRATION 表示 |
+| DESIGN/34 §6 (PR テンプレート) | `.github/pull_request_template.md` | live モード PR チェックリスト |
 | DESIGN/34 §4 (新規安全装置) | `victim-net: internal: true`, `productionGuard`, `Host` 強制上書き, `cap_drop`, `read_only`, `tmpfs` | OS レイヤ防御 |
 | DESIGN/30 §6.2 (`mode` フィールド) | `shared/api-types.ts` (`AttackScenarioMeta.mode`, `liveTemplate`) | live/narration 切替 |
 | DESIGN/30 §5.3 (Phase 2 PoC 第 1 号) | `src/components/auth/attacks/scenarios/jwt-scenarios.ts` (`jwt-alg-none` の `mode: "live"`) + `src/components/auth/JwtInspector.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |

--- a/DESIGN/33-raw-http-composer.md
+++ b/DESIGN/33-raw-http-composer.md
@@ -33,7 +33,7 @@ safety-reviewed: false
 - `AttackScenarioSelector`: 各シナリオ名右側に `[LIVE]` / `[NARRATION]` バッジを追加
 - `AttackPanel`: `meta.mode` を読んで `RawHttpComposer` / 既存実行ボタン を排他表示
 - `DataFlowPanel`: 4 番目のタブ "Sequence" を追加し `SequenceDiagramView` を内包
-- `AttackStepTimeline`: `mode: "live"` では orchestrator レスポンスの `rawExchange` から steps を生成
+- ~~`AttackStepTimeline`: `mode: "live"` では orchestrator レスポンスの `rawExchange` から steps を生成~~ → **PR-1 で obsolete**: orchestrator が live 経路でも probe/exploit|blocked/verify の 3 ステップを生成し `result.steps[]` に詰めて返すため、フロント派生は冗長。raw bytes の視覚化は `SequenceDiagramView` が担当する。詳細は §4.1 参照。
 - `AttackResultBanner` / `AttackDefensePanel`: 変更なし (両モード共通)
 
 ---
@@ -617,6 +617,8 @@ onCleanup(() => {
 
 ### 4.1 変更点
 
+> **注 (PR-1 後 obsolete セクションの統合)**: 当初本仕様には「`AttackStepTimeline` に `liveSteps()` 派生値を追加し `rawExchange` から steps を生成する」という拡張を予定していたが、PR-1 (#14) の実装で `orchestrator-exec.ts` が live 経路でも probe/exploit|blocked/verify の 3 段ステップを `OrchestratorExecResponse.steps[]` に詰めて返す形になったため、フロント側での派生は冗長となった。`AttackStepTimeline` は両モードで `attackResult()?.steps ?? []` を受け取れば十分機能する。raw bytes の視覚化は `SequenceDiagramView` が独立して担当する。本セクションの下記 `AttackPanel` の変更点のみ有効。
+
 `AttackPanel.tsx` に `mode` 判定を追加する。シナリオの `meta.mode` を参照して
 `RawHttpComposer` / 既存実行ボタンを排他表示に切り替える。
 
@@ -860,7 +862,7 @@ if (res.status === 502) {
 | `EducationalWarningBanner.tsx` | `mode` prop 追加。`mode === "live"` 時の LIVE バッジ表示 | 小 (子要素追加のみ) |
 | `AttackScenarioSelector.tsx` | `scenario.mode` を読んで `[LIVE]` / `[NARRATION]` バッジ表示 | 小 |
 | `DataFlowPanel.tsx` | `tab` Signal に `"sequence"` 追加。`isLiveMode` / `rawExchange` prop 追加。Sequence タブボタン + `SequenceDiagramView` 表示 | 中 |
-| `AttackStepTimeline.tsx` | `mode: "live"` では orchestrator レスポンスの `rawExchange` から `steps[]` を変換する `liveSteps()` 派生値を追加 | 中 |
+| ~~`AttackStepTimeline.tsx`~~ | ~~`mode: "live"` では orchestrator レスポンスの `rawExchange` から `steps[]` を変換する `liveSteps()` 派生値を追加~~ → **PR-1 後 obsolete**: orchestrator が steps を返すため不要 | なし |
 | `AttackResultBanner.tsx` | 変更なし (両モードで `AttackResult` を受ける) | なし |
 | `AttackDefensePanel.tsx` | 変更なし | なし |
 

--- a/src/components/shared/AttackPanel.tsx
+++ b/src/components/shared/AttackPanel.tsx
@@ -4,6 +4,8 @@ import type {
   AttackScenarioMeta,
   AttackResult,
   OrchestratorExecRequest,
+  OrchestratorExecResponse,
+  RawExchange,
   VictimTarget,
 } from "../../../shared/api-types";
 import type { AuthSubView } from "../../types/security";
@@ -43,6 +45,7 @@ function AttackPanel(props: AttackPanelProps) {
     props.scenarios[0]?.id ?? ""
   );
   const [attackResult, setAttackResult] = createSignal<AttackResult | null>(null);
+  const [rawExchange, setRawExchange] = createSignal<RawExchange | null>(null);
   const [running, setRunning] = createSignal(false);
   const [defenseOpen, setDefenseOpen] = createSignal(false);
   const [errorMessage, setErrorMessage] = createSignal<string | null>(null);
@@ -71,10 +74,11 @@ function AttackPanel(props: AttackPanelProps) {
     }
   });
 
-  /* シナリオ切替時に直前の結果・エラーをクリア */
+  /* シナリオ切替時に直前の結果・エラー・rawExchange をクリア */
   createEffect(() => {
     selectedId();
     setAttackResult(null);
+    setRawExchange(null);
     setErrorMessage(null);
   });
 
@@ -83,6 +87,7 @@ function AttackPanel(props: AttackPanelProps) {
     if (!scenario || running()) return;
     setRunning(true);
     setAttackResult(null);
+    setRawExchange(null);
     setDefenseOpen(false);
     setErrorMessage(null);
     try {
@@ -101,11 +106,16 @@ function AttackPanel(props: AttackPanelProps) {
     if (!scenario || running() || !props.onRunLiveScenario) return;
     setRunning(true);
     setAttackResult(null);
+    setRawExchange(null);
     setDefenseOpen(false);
     setErrorMessage(null);
     try {
       const result = await props.onRunLiveScenario(scenario, payload);
       setAttackResult(result);
+      // OrchestratorExecResponse extends AttackResult & { rawExchange, mode: "live" }。
+      // success path のみ runtime で rawExchange を保持する (error fallback path は plain AttackResult)。
+      const live = result as Partial<OrchestratorExecResponse>;
+      setRawExchange(live.rawExchange ?? null);
       if (result.outcome === "error") {
         setErrorMessage(result.summaryJa ?? result.summary ?? t("実行エラー", "Execution error"));
       }
@@ -116,8 +126,8 @@ function AttackPanel(props: AttackPanelProps) {
 
   return (
     <div class="attack-panel">
-      {/* 1. 教育用バナー (常時表示) */}
-      <EducationalWarningBanner />
+      {/* 1. 教育用バナー (常時表示)。live モードでは LIVE バッジを付与 */}
+      <EducationalWarningBanner mode={isLiveMode() ? "live" : "narration"} />
 
       <div class="attack-panel-inner">
         {/* 2. シナリオセレクタ */}
@@ -208,8 +218,13 @@ function AttackPanel(props: AttackPanelProps) {
           <AttackResultBanner result={attackResult()!} />
         </Show>
 
-        {/* 8. DataFlowPanel */}
-        <DataFlowPanel scopeId={`attack-${props.tabId}`} defaultOpen={false} />
+        {/* 8. DataFlowPanel — live モード時のみ Sequence タブが露出する */}
+        <DataFlowPanel
+          scopeId={`attack-${props.tabId}`}
+          defaultOpen={false}
+          isLiveMode={isLiveMode()}
+          rawExchange={rawExchange()}
+        />
       </div>
     </div>
   );

--- a/src/components/shared/AttackScenarioSelector.css
+++ b/src/components/shared/AttackScenarioSelector.css
@@ -146,3 +146,35 @@
   background: var(--color-success-muted);
   color: var(--color-success);
 }
+
+/* ── モードバッジ (LIVE / NARRATION) ── */
+.scenario-mode-badge {
+  display: inline-block;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  letter-spacing: 0.06em;
+  flex-shrink: 0;
+  border: 1px solid transparent;
+}
+
+.scenario-mode-badge[data-mode="live"] {
+  background: var(--color-attack-bg);
+  color: var(--color-attack-accent);
+  border-color: var(--color-attack-accent);
+}
+
+.scenario-mode-badge[data-mode="narration"] {
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  border-color: var(--border-subtle);
+}
+
+.attack-scenario-badges {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}

--- a/src/components/shared/AttackScenarioSelector.tsx
+++ b/src/components/shared/AttackScenarioSelector.tsx
@@ -29,7 +29,10 @@ function AttackScenarioSelector(props: AttackScenarioSelectorProps) {
           <div class="attack-scenario-desc">
             {t(selected()?.descriptionJa ?? "", selected()?.description ?? "")}
           </div>
-          <SeverityBadge severity={selected()?.severity ?? "info"} />
+          <div class="attack-scenario-badges">
+            <SeverityBadge severity={selected()?.severity ?? "info"} />
+            <ModeBadge mode={selected()?.mode} />
+          </div>
         </div>
       </Show>
 
@@ -56,6 +59,7 @@ function AttackScenarioSelector(props: AttackScenarioSelectorProps) {
                   {t(scenario.nameJa, scenario.name)}
                 </span>
                 <SeverityBadge severity={scenario.severity} />
+                <ModeBadge mode={scenario.mode} />
                 <Show when={scenario.cweId && /^CWE-\d+$/.test(scenario.cweId)}>
                   <a
                     class="attack-chip-ref"
@@ -116,6 +120,26 @@ function SeverityBadge(badgeProps: { severity: string }) {
   return (
     <span class="severity-badge" data-severity={badgeProps.severity}>
       {badgeProps.severity.toUpperCase()}
+    </span>
+  );
+}
+
+/**
+ * シナリオの実行モード (`live` / `narration`) を示すバッジ。
+ * 未指定の場合は `narration` 扱い。DESIGN/33 §5.2 準拠。
+ */
+function ModeBadge(badgeProps: { mode?: "live" | "narration" }) {
+  const resolved = badgeProps.mode ?? "narration";
+  return (
+    <span
+      class="scenario-mode-badge"
+      data-mode={resolved}
+      aria-label={resolved === "live"
+        ? "LIVE attack mode (real HTTP)"
+        : "Narration mode (server-rendered simulation)"
+      }
+    >
+      {resolved === "live" ? "LIVE" : "NARRATION"}
     </span>
   );
 }

--- a/src/components/shared/DataFlowPanel.tsx
+++ b/src/components/shared/DataFlowPanel.tsx
@@ -1,20 +1,34 @@
 import { createSignal, createEffect, Show, For } from "solid-js";
 import { useI18n } from "../../i18n/context";
 import type { CapturedExchange, ServerTrace, CryptoOp, DbQuery, SessionOp } from "../../api/client";
-import type { AttackStep } from "../../../shared/api-types";
+import type { AttackStep, RawExchange } from "../../../shared/api-types";
 import { getScopedExchanges } from "../../api/client";
 import { safeStringify } from "../../utils/safe-stringify";
+import SequenceDiagramView from "./SequenceDiagramView";
 import "./DataFlowPanel.css";
 
 interface DataFlowPanelProps {
   scopeId: string;
   defaultOpen?: boolean;
+  /** mode: "live" シナリオ実行中のみ true。Sequence タブを露出するか判定 (DESIGN/33 §4.3) */
+  isLiveMode?: boolean;
+  /** 直近の orchestrator/exec レスポンスから抽出した raw exchange。null/未指定時は空状態 */
+  rawExchange?: RawExchange | null;
 }
+
+type DataFlowTab = "http" | "trace" | "db" | "sequence";
 
 export default function DataFlowPanel(props: DataFlowPanelProps) {
   const { t } = useI18n();
   const [open, setOpen] = createSignal(props.defaultOpen ?? false);
-  const [tab, setTab] = createSignal<"http" | "trace" | "db">("http");
+  const [tab, setTab] = createSignal<DataFlowTab>("http");
+
+  // live モードを抜けた瞬間に sequence タブを選択していたら http に戻す
+  createEffect(() => {
+    if (!props.isLiveMode && tab() === "sequence") {
+      setTab("http");
+    }
+  });
 
   const exs = () => getScopedExchanges(props.scopeId)();
 
@@ -41,6 +55,11 @@ export default function DataFlowPanel(props: DataFlowPanelProps) {
           <button class="data-flow-tab" role="tab" aria-selected={tab() === "db"} data-active={tab() === "db"} onClick={() => setTab("db")}>
             {t("DB操作", "DB Queries")}
           </button>
+          <Show when={props.isLiveMode}>
+            <button class="data-flow-tab" role="tab" aria-selected={tab() === "sequence"} data-active={tab() === "sequence"} onClick={() => setTab("sequence")}>
+              {t("シーケンス", "Sequence")}
+            </button>
+          </Show>
         </div>
 
         <div class="data-flow-content" role="tabpanel" aria-live="polite">
@@ -52,6 +71,12 @@ export default function DataFlowPanel(props: DataFlowPanelProps) {
           </Show>
           <Show when={tab() === "db"}>
             <DbQueryView exchanges={exs()} />
+          </Show>
+          <Show when={tab() === "sequence" && props.isLiveMode}>
+            <SequenceDiagramView
+              exchange={props.rawExchange ?? null}
+              scenarioId={props.scopeId}
+            />
           </Show>
         </div>
       </Show>

--- a/src/components/shared/EducationalWarningBanner.css
+++ b/src/components/shared/EducationalWarningBanner.css
@@ -23,4 +23,19 @@
 
 .edu-warning-text {
   line-height: 1.4;
+  flex: 1 1 auto;
+}
+
+.edu-warning-live-badge {
+  margin-left: auto;
+  flex-shrink: 0;
+  background: var(--color-attack-bg);
+  color: var(--color-attack-accent);
+  border: 2px solid var(--color-attack-accent);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 2px 8px;
+  letter-spacing: 0.12em;
 }

--- a/src/components/shared/EducationalWarningBanner.tsx
+++ b/src/components/shared/EducationalWarningBanner.tsx
@@ -1,16 +1,26 @@
+import { Show } from "solid-js";
 import { useI18n } from "../../i18n/context";
 import "./EducationalWarningBanner.css";
+
+interface EducationalWarningBannerProps {
+  /**
+   * `"live"` のとき右端に LIVE バッジを表示する (DESIGN/33 §5.1)。
+   * 未指定または `"narration"` の場合はバッジ非表示。
+   */
+  mode?: "live" | "narration";
+}
 
 /**
  * 攻撃者モード (Attacker View) で常時表示する教育用バナー。
  * dismissable 禁止: 閉じるボタンなし、display:none/visibility:hidden 実装禁止。
  * DESIGN/04 §6 完全準拠。
  */
-function EducationalWarningBanner() {
+function EducationalWarningBanner(props: EducationalWarningBannerProps) {
   const { t } = useI18n();
   return (
     <div
       class="edu-warning-banner"
+      data-mode={props.mode ?? "narration"}
       role="note"
       aria-live="polite"
       aria-label={t("教育用シミュレーション警告", "Educational simulation warning")}
@@ -22,6 +32,14 @@ function EducationalWarningBanner() {
           "Educational simulation — not for use against real systems"
         )}
       </span>
+      <Show when={props.mode === "live"}>
+        <span
+          class="edu-warning-live-badge"
+          aria-label={t("LIVE 攻撃モード — 実 HTTP を Docker victim に送信します", "LIVE attack mode — sends real HTTP to the Docker victim")}
+        >
+          LIVE
+        </span>
+      </Show>
     </div>
   );
 }

--- a/src/components/shared/RawHttpComposer.css
+++ b/src/components/shared/RawHttpComposer.css
@@ -164,6 +164,33 @@
   outline-offset: 1px;
 }
 
+.rhc-raw {
+  margin: 0;
+  padding: 8px 10px;
+  width: 100%;
+  max-height: 240px;
+  overflow: auto;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  white-space: pre-wrap;
+  word-break: break-all;
+  user-select: text;
+  cursor: default;
+}
+
+.rhc-raw-note {
+  margin: 0.4rem 0 0;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
 .rhc-send {
   align-self: flex-start;
   background: var(--color-attack-accent);

--- a/src/components/shared/RawHttpComposer.tsx
+++ b/src/components/shared/RawHttpComposer.tsx
@@ -55,7 +55,25 @@ function RawHttpComposer(props: RawHttpComposerProps) {
       .map(([key, value]) => ({ key, value })),
   );
   const [body, setBody] = createSignal<string>(props.template.body);
-  const [activeTab, setActiveTab] = createSignal<"headers" | "body">("body");
+  const [activeTab, setActiveTab] = createSignal<"headers" | "body" | "raw">("body");
+
+  /**
+   * Raw タブ用の派生値。本物の HTTP プレコンパイルではなく可視化用。
+   * Host ヘッダは orchestrator が常に強制上書きするため、プレビューとして表示する。
+   * 編集系操作 (copy/export/persist) は意図的に提供しない (DESIGN/33 §2.4)。
+   */
+  const rawPreview = () => {
+    const userHeaders = headers()
+      .filter((h) => h.key.trim() && h.key.trim().toLowerCase() !== "host")
+      .map((h) => `${h.key.trim()}: ${h.value}`);
+    const lines = [
+      `${method()} ${path() || "/"} HTTP/1.1`,
+      "Host: <victim host> (orchestrator が強制設定 / set by orchestrator)",
+      ...userHeaders,
+    ];
+    const bodyStr = body();
+    return [...lines, "", bodyStr].join("\r\n");
+  };
 
   function updateHeader(idx: number, patch: Partial<HeaderEntry>) {
     setHeaders((prev) =>
@@ -165,6 +183,16 @@ function RawHttpComposer(props: RawHttpComposerProps) {
         >
           {t("ボディ", "Body")}
         </button>
+        <button
+          type="button"
+          class="rhc-tab"
+          role="tab"
+          aria-selected={activeTab() === "raw"}
+          data-active={activeTab() === "raw"}
+          onClick={() => setActiveTab("raw")}
+        >
+          {t("Raw", "Raw")}
+        </button>
       </div>
 
       <div class="raw-http-composer-tabpanel" role="tabpanel">
@@ -233,6 +261,21 @@ function RawHttpComposer(props: RawHttpComposerProps) {
               'e.g. {"token":"<forged JWT>"}',
             )}
           />
+        </Show>
+
+        <Show when={activeTab() === "raw"}>
+          <pre
+            class="rhc-raw"
+            aria-label={t("生 HTTP プレビュー (読み取り専用)", "Raw HTTP preview (read-only)")}
+          >
+            {rawPreview()}
+          </pre>
+          <p class="rhc-raw-note">
+            {t(
+              "プレビューのみ。Host ヘッダは送信時に orchestrator が解決した victim ホストへ強制上書きされます。",
+              "Preview only. The Host header is overwritten at send time by the orchestrator to the resolved victim host.",
+            )}
+          </p>
         </Show>
       </div>
 

--- a/src/components/shared/SequenceDiagramView.css
+++ b/src/components/shared/SequenceDiagramView.css
@@ -1,0 +1,186 @@
+.sequence-diagram-view {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+}
+
+.sequence-diagram-svg {
+  width: 100%;
+  height: auto;
+  max-height: 400px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+
+.sequence-diagram-empty {
+  padding: 1.5rem 1rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  background: var(--bg-card);
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+
+.sequence-diagram-hint {
+  margin: 0;
+  padding: 0;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+/* ── Static layer ── */
+.seq-actor-box {
+  fill: var(--bg-card);
+  stroke: var(--border-subtle);
+  stroke-width: 1;
+}
+
+.seq-actor-label {
+  fill: var(--text-primary);
+  font-size: 12px;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.seq-lifeline {
+  stroke: var(--border-subtle);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+}
+
+/* ── Arrows ── */
+.seq-arrow-line {
+  stroke-width: 2;
+  fill: none;
+}
+
+.seq-arrow-group.seq-arrow-request .seq-arrow-line {
+  stroke: var(--color-attack-accent);
+}
+
+.seq-arrow-group.seq-arrow-response .seq-arrow-line {
+  stroke: var(--color-info, #1677ff);
+}
+
+.seq-arrow-group:hover .seq-arrow-line,
+.seq-arrow-group.seq-arrow-focused .seq-arrow-line {
+  stroke-width: 3;
+}
+
+.seq-arrow-label {
+  fill: var(--text-secondary);
+  font-size: 10px;
+  font-family: var(--font-mono);
+  pointer-events: none;
+}
+
+.seq-arrow-group.seq-arrow-request .seq-arrow-label {
+  fill: var(--color-attack-accent);
+}
+
+.seq-arrow-group.seq-arrow-response .seq-arrow-label {
+  fill: var(--color-info, #1677ff);
+}
+
+.seq-arrow-elapsed {
+  fill: var(--text-muted);
+  font-size: 9px;
+  font-family: var(--font-mono);
+  font-style: italic;
+  pointer-events: none;
+}
+
+.seq-arrow-hitbox {
+  cursor: pointer;
+}
+
+.seq-arrow-hitbox:focus {
+  outline: 2px solid var(--glow-color);
+  outline-offset: 2px;
+}
+
+/* ── Raw bytes popup ── */
+.raw-bytes-popup-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.raw-bytes-popup {
+  width: min(640px, 92vw);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-card);
+  border: 1px solid var(--color-attack-accent);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  font-family: var(--font-mono);
+}
+
+.raw-bytes-popup-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.raw-bytes-popup-title {
+  flex: 1;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  word-break: break-all;
+}
+
+.raw-bytes-popup-title[data-direction="request"] {
+  color: var(--color-attack-accent);
+}
+
+.raw-bytes-popup-title[data-direction="response"] {
+  color: var(--color-info, #1677ff);
+}
+
+.raw-bytes-popup-close {
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  width: 1.6rem;
+  height: 1.6rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.raw-bytes-popup-close:hover {
+  color: var(--color-attack-accent);
+  border-color: var(--color-attack-accent);
+}
+
+.raw-bytes-popup-body {
+  flex: 1;
+  margin: 0;
+  padding: 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  background: var(--bg-primary);
+  border-bottom-left-radius: var(--radius-md);
+  border-bottom-right-radius: var(--radius-md);
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}

--- a/src/components/shared/SequenceDiagramView.tsx
+++ b/src/components/shared/SequenceDiagramView.tsx
@@ -1,0 +1,355 @@
+import { onMount, onCleanup, createEffect, createSignal, Show } from "solid-js";
+import { select, type Selection } from "d3-selection";
+import "d3-transition";
+import { useI18n } from "../../i18n/context";
+import type { RawExchange } from "../../../shared/api-types";
+import "./SequenceDiagramView.css";
+
+/**
+ * Live attack シーケンス図。
+ *
+ * Browser → Orchestrator → Victim の 3 アクター間で交わされた
+ * raw HTTP exchange を D3 SVG スイムレーンで可視化する。
+ * 矢印クリックで raw bytes ポップアップを表示。
+ *
+ * 関連設計書: DESIGN/33 §3
+ */
+
+interface SequenceDiagramViewProps {
+  /** orchestrator レスポンスの rawExchange。null/undefined の場合は空状態を表示 */
+  exchange: RawExchange | null | undefined;
+  scenarioId: string;
+}
+
+type ActorKey = "browser" | "orchestrator" | "victim";
+
+interface RawArrow {
+  from: ActorKey;
+  to: ActorKey;
+  /** 矢印ラベル (例: "POST /jwt/verify HTTP/1.1") */
+  label: string;
+  direction: "request" | "response";
+  /** クリック popup で表示する生テキスト (request line + headers + body) */
+  rawBytes: string;
+  elapsedMs?: number;
+}
+
+const ACTOR_LABELS: Record<ActorKey, { ja: string; en: string }> = {
+  browser: { ja: "Browser", en: "Browser" },
+  orchestrator: { ja: "Orchestrator", en: "Orchestrator" },
+  victim: { ja: "Victim", en: "Victim" },
+};
+
+const VIEW_WIDTH = 720;
+const VIEW_HEIGHT = 360;
+const ACTOR_X: Record<ActorKey, number> = {
+  browser: 100,
+  orchestrator: 360,
+  victim: 620,
+};
+const HEADER_Y = 32;
+const FIRST_ARROW_Y = 96;
+const ARROW_GAP = 56;
+const LIFELINE_BOTTOM = 320;
+const ARROW_TRANSITION_MS = 400;
+const ARROW_STAGGER_MS = 250;
+
+function deriveArrows(ex: RawExchange): RawArrow[] {
+  const b2o = ex.browserToOrchestrator;
+  const o2v = ex.orchestratorToVictim;
+
+  const formatHeaders = (h: Record<string, string>) =>
+    Object.entries(h).map(([k, v]) => `${k}: ${v}`).join("\r\n");
+  const renderRaw = (
+    line: string,
+    headers: Record<string, string>,
+    body: string | null | undefined,
+  ) => {
+    const headerStr = formatHeaders(headers);
+    const bodyStr = body ?? "";
+    return `${line}\r\n${headerStr}\r\n\r\n${bodyStr}`;
+  };
+
+  return [
+    {
+      from: "browser",
+      to: "orchestrator",
+      label: b2o.request.line,
+      direction: "request",
+      rawBytes: renderRaw(b2o.request.line, b2o.request.headers, b2o.request.body),
+    },
+    {
+      from: "orchestrator",
+      to: "victim",
+      label: o2v.request.line,
+      direction: "request",
+      rawBytes: renderRaw(o2v.request.line, o2v.request.headers, o2v.request.body),
+      elapsedMs: ex.elapsedMs,
+    },
+    {
+      from: "victim",
+      to: "orchestrator",
+      label: o2v.response.line,
+      direction: "response",
+      rawBytes: renderRaw(o2v.response.line, o2v.response.headers, o2v.response.body),
+    },
+    {
+      from: "orchestrator",
+      to: "browser",
+      label: b2o.response.line,
+      direction: "response",
+      rawBytes: renderRaw(b2o.response.line, b2o.response.headers, b2o.response.body),
+    },
+  ];
+}
+
+function SequenceDiagramView(props: SequenceDiagramViewProps) {
+  const { t } = useI18n();
+  let svgRef: SVGSVGElement | undefined;
+  const [popupArrow, setPopupArrow] = createSignal<RawArrow | null>(null);
+
+  function initStaticLayer(svg: Selection<SVGSVGElement, unknown, null, undefined>) {
+    const defs = svg.append("defs");
+
+    for (const dir of ["request", "response"] as const) {
+      const color = dir === "request"
+        ? "var(--color-attack-accent)"
+        : "var(--color-info, #1677ff)";
+      defs
+        .append("marker")
+        .attr("id", `seq-arrow-${dir}`)
+        .attr("viewBox", "0 -5 10 10")
+        .attr("refX", 8)
+        .attr("refY", 0)
+        .attr("markerWidth", 6)
+        .attr("markerHeight", 6)
+        .attr("orient", "auto")
+        .append("path")
+        .attr("d", "M0,-5L10,0L0,5")
+        .attr("fill", color);
+    }
+
+    const headerGroup = svg.append("g").attr("class", "seq-headers");
+    const lifelineGroup = svg.append("g").attr("class", "seq-lifelines");
+
+    (Object.keys(ACTOR_X) as ActorKey[]).forEach((actor) => {
+      const x = ACTOR_X[actor];
+      headerGroup
+        .append("rect")
+        .attr("class", "seq-actor-box")
+        .attr("x", x - 70)
+        .attr("y", HEADER_Y - 20)
+        .attr("width", 140)
+        .attr("height", 32)
+        .attr("rx", 4);
+      headerGroup
+        .append("text")
+        .attr("class", "seq-actor-label")
+        .attr("x", x)
+        .attr("y", HEADER_Y)
+        .attr("text-anchor", "middle")
+        .attr("dominant-baseline", "middle")
+        .text(ACTOR_LABELS[actor].en);
+
+      lifelineGroup
+        .append("line")
+        .attr("class", "seq-lifeline")
+        .attr("x1", x)
+        .attr("y1", HEADER_Y + 16)
+        .attr("x2", x)
+        .attr("y2", LIFELINE_BOTTOM);
+    });
+
+    svg.append("g").attr("class", "seq-arrows");
+  }
+
+  function drawArrows(
+    svg: Selection<SVGSVGElement, unknown, null, undefined>,
+    arrows: RawArrow[],
+  ) {
+    const arrowsGroup = svg.select<SVGGElement>("g.seq-arrows");
+    arrowsGroup.selectAll("*").interrupt();
+    arrowsGroup.selectAll("*").remove();
+
+    arrows.forEach((arrow, idx) => {
+      const fromX = ACTOR_X[arrow.from];
+      const toX = ACTOR_X[arrow.to];
+      const y = FIRST_ARROW_Y + idx * ARROW_GAP;
+      const colorClass = `seq-arrow-${arrow.direction}`;
+
+      const group = arrowsGroup
+        .append("g")
+        .attr("class", `seq-arrow-group ${colorClass}`)
+        .style("cursor", "pointer")
+        .on("click", () => setPopupArrow(arrow))
+        .on("keydown", (event: KeyboardEvent) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            setPopupArrow(arrow);
+          }
+        });
+
+      group.append("title").text(arrow.label);
+
+      const labelMidX = (fromX + toX) / 2;
+      group
+        .append("text")
+        .attr("class", "seq-arrow-label")
+        .attr("x", labelMidX)
+        .attr("y", y - 8)
+        .attr("text-anchor", "middle")
+        .text(arrow.label);
+
+      const line = group
+        .append("line")
+        .attr("class", "seq-arrow-line")
+        .attr("x1", fromX)
+        .attr("y1", y)
+        .attr("x2", fromX)
+        .attr("y2", y)
+        .attr("marker-end", `url(#seq-arrow-${arrow.direction})`);
+
+      const hitbox = group
+        .append("rect")
+        .attr("class", "seq-arrow-hitbox")
+        .attr("x", Math.min(fromX, toX))
+        .attr("y", y - 14)
+        .attr("width", Math.abs(toX - fromX))
+        .attr("height", 28)
+        .attr("fill", "transparent")
+        .attr("tabindex", 0)
+        .attr("role", "button")
+        .attr("aria-label", arrow.label);
+
+      // delayed reveal
+      line
+        .transition()
+        .delay(idx * ARROW_STAGGER_MS)
+        .duration(ARROW_TRANSITION_MS)
+        .attr("x2", toX);
+
+      // elapsedMs annotation (only on orchestrator→victim arrow)
+      if (arrow.elapsedMs !== undefined) {
+        group
+          .append("text")
+          .attr("class", "seq-arrow-elapsed")
+          .attr("x", labelMidX)
+          .attr("y", y + 16)
+          .attr("text-anchor", "middle")
+          .text(`${arrow.elapsedMs} ms`);
+      }
+
+      // a11y: focus highlights line
+      hitbox.on("focus", () => group.classed("seq-arrow-focused", true));
+      hitbox.on("blur", () => group.classed("seq-arrow-focused", false));
+    });
+  }
+
+  onMount(() => {
+    if (!svgRef) return;
+    const svg = select(svgRef)
+      .attr("viewBox", `0 0 ${VIEW_WIDTH} ${VIEW_HEIGHT}`)
+      .attr("preserveAspectRatio", "xMidYMid meet");
+    initStaticLayer(svg);
+
+    const ex = props.exchange;
+    if (ex) {
+      drawArrows(svg, deriveArrows(ex));
+    }
+  });
+
+  createEffect(() => {
+    const ex = props.exchange;
+    if (!svgRef) return;
+    const svg = select(svgRef);
+    if (!ex) {
+      svg.select("g.seq-arrows").selectAll("*").interrupt();
+      svg.select("g.seq-arrows").selectAll("*").remove();
+      setPopupArrow(null);
+      return;
+    }
+    drawArrows(svg, deriveArrows(ex));
+  });
+
+  onCleanup(() => {
+    if (svgRef) {
+      select(svgRef).selectAll("*").interrupt();
+    }
+  });
+
+  return (
+    <div class="sequence-diagram-view">
+      <Show
+        when={props.exchange}
+        fallback={
+          <div class="sequence-diagram-empty">
+            {t(
+              "live 攻撃をまだ実行していません。RawHttpComposer から送信してください。",
+              "No live attack run yet. Send a request from RawHttpComposer.",
+            )}
+          </div>
+        }
+      >
+        <svg
+          ref={svgRef}
+          class="sequence-diagram-svg"
+          role="img"
+          aria-label={t(
+            "Browser・Orchestrator・Victim 間のシーケンス図",
+            "Sequence diagram across Browser, Orchestrator, and Victim",
+          )}
+          data-scenario-id={props.scenarioId}
+        />
+        <p class="sequence-diagram-hint">
+          {t(
+            "矢印をクリックすると raw bytes を表示します。",
+            "Click an arrow to view the raw bytes.",
+          )}
+        </p>
+      </Show>
+
+      <Show when={popupArrow() !== null}>
+        <RawBytesPopup
+          arrow={popupArrow()!}
+          onClose={() => setPopupArrow(null)}
+        />
+      </Show>
+    </div>
+  );
+}
+
+function RawBytesPopup(props: { arrow: RawArrow; onClose: () => void }) {
+  const { t } = useI18n();
+  return (
+    <div
+      class="raw-bytes-popup-overlay"
+      role="presentation"
+      onClick={props.onClose}
+    >
+      <div
+        class="raw-bytes-popup"
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("生バイト表示", "Raw bytes")}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div class="raw-bytes-popup-header">
+          <span class="raw-bytes-popup-title" data-direction={props.arrow.direction}>
+            {props.arrow.label}
+          </span>
+          <button
+            type="button"
+            class="raw-bytes-popup-close"
+            aria-label={t("閉じる", "Close")}
+            onClick={props.onClose}
+          >
+            ×
+          </button>
+        </div>
+        <pre class="raw-bytes-popup-body">{props.arrow.rawBytes || t("(空)", "(empty)")}</pre>
+      </div>
+    </div>
+  );
+}
+
+export default SequenceDiagramView;


### PR DESCRIPTION
## 概要 / Summary

Phase 1 の 2 番目の PR。DESIGN/33 を実装に落として、live モードシナリオの可視化と排他切替を完成させた。
PR-1 (#14) で配線した jwt-alg-none をベースに UI 完成度を上げる。

## 関連 Issue / Linked issues

- refs #8 (Phase 1: インフラ整備)

## 変更点 / Changes

**新規ファイル**
- `src/components/shared/SequenceDiagramView.{tsx,css}`: D3 SVG で 3 アクター swimlane (Browser/Orchestrator/Victim) + 矢印クリックで raw bytes ポップアップ。`d3-selection` + `d3-transition` の既存依存のみで完結 (座標は固定値で自前計算)
- `.github/pull_request_template.md`: live モード PR チェックリスト (DESIGN/34 §6 由来)

**既存ファイルへの拡張**
- `DataFlowPanel.tsx`: 4 番目のタブ "Sequence" を追加、`isLiveMode` / `rawExchange` の 2 props を受け取り live 時のみ Sequence タブを露出。narration 切替時は http タブへ自動退避
- `AttackPanel.tsx`: `rawExchange` Signal を追加、`OrchestratorExecResponse` 由来の `rawExchange` を局所キャストで抽出して `DataFlowPanel` に伝播。シナリオ切替時にクリア
- `EducationalWarningBanner.tsx`: `mode` prop + LIVE バッジ
- `AttackScenarioSelector.tsx`: `ModeBadge` コンポーネント追加で各シナリオに `LIVE`/`NARRATION` 表示
- `RawHttpComposer.tsx`: `Raw` タブ追加 (読み取り専用プレビュー、export/copy/persist は提供しない)

**設計ドキュメント整合**
- `DESIGN/33-raw-http-composer.md`: §4.1 (`AttackStepTimeline` live 派生) を **PR-1 後 obsolete** として明記。理由は本 PR 末尾の「設計判断」参照
- `CLAUDE.md`: DESIGN ⇄ 実装 対応表を更新

## 設計判断 / Design decisions

- **AttackStepTimeline の live 派生は実装しなかった**: PR-1 で orchestrator が live 経路でも `probe`/`exploit`|`blocked`/`verify` の 3 段 `AttackStep` を `OrchestratorExecResponse.steps[]` に詰めて返す形に確定したため、フロント側での派生は冗長。raw bytes 視覚化は `SequenceDiagramView` が独立して担当する役割分担に整理した
- **D3 依存追加なし**: SequenceDiagramView は `d3-scale` 等を新規依存にせず、既存 LayerDiagram と同じ `select` + `import \"d3-transition\"` パターンで実装。ライフライン X 座標は定数 3 点 (`{browser:100, orchestrator:360, victim:620}`) で十分
- **rawExchange の伝播経路**: `onRunLiveScenario` の戻り型は `Promise<AttackResult>` のまま変更せず、`AttackPanel` 内で `(result as Partial<OrchestratorExecResponse>).rawExchange ?? null` の局所キャスト 1 箇所で抽出。I/F 汚染を最小化

## スクリーンショット / Screenshots

(preview server で `jwt-alg-none` を実行した画面を後段で添付予定)

## テスト方法 / How to test

- [x] `npm run dev:no-docker` でフロント:3000 + バックエンド:3001 + victim-web:4001 を起動 (本 PR では preview 経由で確認)
- [x] 認証 → JWT タブ → 攻撃者モードで `alg=none 攻撃` シナリオを選択
- [x] `EducationalWarningBanner` 右端に `LIVE` バッジが表示される
- [x] 各シナリオチップに `LIVE` / `NARRATION` バッジが表示される
- [x] `RawHttpComposer` が表示され Raw タブで生 HTTP プレビューを確認できる
- [x] 「送信 (LIVE)」を押下 → 3 ステップが `SUCCESS` で表示され、攻撃成立バナー
- [x] `DataFlowPanel` を開き Sequence タブ → 4 矢印 + 矢印クリックで raw bytes popup
- [x] 別シナリオ (NARRATION) に切替 → LIVE バッジ・Composer・Sequence タブが消える
- [x] `alg=none` に戻ると rawExchange はクリアされ「live 攻撃をまだ実行していません」と表示

**自動テスト**
- [x] `npm run test:ci` 464 / 464 pass
- [x] `npx tsc --noEmit` エラー 0
- [x] ブラウザコンソールエラー 0

## DESIGN ⇄ 実装 整合性

- [x] DESIGN/33 §3, §4, §5 を実装
- [x] DESIGN/33 §4.1 を obsolete として注記
- [x] DESIGN/34 §6 から PR テンプレートを生成
- [x] CLAUDE.md DESIGN ⇄ 実装 対応表に新規ファイルを追加

---

## live モード PR チェックリスト

> 本 PR は live モード UI を扱うため記入。

### DESIGN/34 §3 チェックリスト

- [x] §3.1 隔離 — orchestrator 経由のみ、victim への直結ルートなし
- [x] §3.2 表示・文言 — LIVE バッジ + Raw タブ脚注で「Host は orchestrator が強制設定」を明示
- [x] §3.3 教育内容 — `AttackDefensePanel` 自動展開を維持
- [x] §3.4 ペイロード — Raw タブは read-only `<pre>`、export/copy/persist 系は実装せず
- [x] §3.5 ログ・デバッグ — `console.log` 追加なし、`localStorage`/`sessionStorage` 書き込みなし

### live UI 確認

- [x] `EducationalWarningBanner` の `LIVE` バッジが live シナリオ選択時のみ表示
- [x] `AttackScenarioSelector` の各シナリオに `LIVE` / `NARRATION` バッジ
- [x] `RawHttpComposer` の Host ヘッダ入力欄が `disabled` のまま
- [x] `RawHttpComposer` に export/copy/persist ボタンを追加していない
- [x] `DataFlowPanel` の `Sequence` タブが live 時のみ露出
- [x] `SequenceDiagramView` の矢印クリックで raw bytes ポップアップが開く
- [x] `localStorage` / `sessionStorage` への書き込みが追加されていない

### Docker 環境確認

- [x] Phase 1-2 暫定運用として `victim-net: internal: true` を無効化したまま (PR-1 の `docker-compose.yml` コメント参照)
- [ ] Phase 3+ 切替時に復活予定 — PR-2 のスコープ外