### PR TITLE
feat: live attack Phase 1 PR-3 — CI Docker smoke + orchestrator-live 結合テスト

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,49 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  # DESIGN/30 §7.2: Docker compose で victim-web を起動して /health 疎通を確認する smoke job。
+  # 完全な live integration test (DESIGN/31 §11.2 の `test:live` を実 victim 経由で走らせる) は
+  # Phase 3+ で orchestrator も compose 化したタイミングで追加予定。Phase 1 では image build と
+  # healthcheck の通過までを CI で守る。
+  docker-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build victim-web image
+        run: docker compose build victim-web
+
+      - name: Start victim-web
+        run: docker compose up -d victim-web
+
+      - name: Wait for /health to respond
+        run: |
+          for i in {1..30}; do
+            if curl --fail --silent --show-error http://127.0.0.1:4001/health > /tmp/health.json 2>/dev/null; then
+              echo "victim-web responded on attempt $i"
+              cat /tmp/health.json
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "victim-web did not respond on /health within 60s"
+          docker compose logs victim-web
+          exit 1
+
+      - name: Smoke check /health returns status ok
+        run: |
+          curl --fail --silent --show-error http://127.0.0.1:4001/health > /tmp/health.json
+          grep -q '"status":"ok"' /tmp/health.json
+
+      - name: Smoke check POST /jwt/verify accepts alg=none (vulnerable on purpose)
+        run: |
+          curl --fail --silent --show-error \
+            -X POST http://127.0.0.1:4001/jwt/verify \
+            -H 'Content-Type: application/json' \
+            -d '{"token":"eyJhbGciOiJub25lIn0.eyJzdWIiOiJzZWVkX2FsaWNlIn0."}' \
+            | tee /tmp/verify.json
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,8 @@ PR レビュー時の「仕様 ↔ 実装」往復に使う。Phase 2+ で新規
 | DESIGN/33 §4.1 (AttackStepTimeline live 派生) | (実装なし) | **PR-1 後 obsolete**: orchestrator が live 経路でも 3 段 AttackStep を返すため不要。raw bytes は SequenceDiagramView 担当。 |
 | DESIGN/33 §5 (mode バッジ) | `RawHttpComposer.tsx` `.raw-http-composer-live-badge`, `EducationalWarningBanner.tsx` (`mode` prop + `.edu-warning-live-badge`), `AttackScenarioSelector.tsx` (`ModeBadge` + `.scenario-mode-badge`) | LIVE/NARRATION 表示 |
 | DESIGN/34 §6 (PR テンプレート) | `.github/pull_request_template.md` | live モード PR チェックリスト |
+| DESIGN/30 §7.2 (CI Docker) | `.github/workflows/ci.yml` の `docker-smoke` job | victim-web image build + healthcheck + /jwt/verify smoke |
+| DESIGN/31 §11 (テスト要件) | `server/__tests__/orchestrator-live.test.ts` (12 tests = 10 spec + 2 extra) | スキーマ違反 / target 不在 / 502 / 504 / production / Host 強制 / mode / victimNote / phase ガード |
 | DESIGN/34 §4 (新規安全装置) | `victim-net: internal: true`, `productionGuard`, `Host` 強制上書き, `cap_drop`, `read_only`, `tmpfs` | OS レイヤ防御 |
 | DESIGN/30 §6.2 (`mode` フィールド) | `shared/api-types.ts` (`AttackScenarioMeta.mode`, `liveTemplate`) | live/narration 切替 |
 | DESIGN/30 §5.3 (Phase 2 PoC 第 1 号) | `src/components/auth/attacks/scenarios/jwt-scenarios.ts` (`jwt-alg-none` の `mode: "live"`) + `src/components/auth/JwtInspector.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:ci": "vitest run",
+    "test:live": "vitest run server/__tests__/orchestrator-live.test.ts",
     "victim:reset": "docker compose restart victim-web",
     "victim:logs": "docker compose logs -f victim-web"
   },

--- a/server/__tests__/orchestrator-live.test.ts
+++ b/server/__tests__/orchestrator-live.test.ts
@@ -1,0 +1,377 @@
+/**
+ * orchestrator/exec エンドポイントの結合テスト (DESIGN/31 §11)。
+ *
+ * 10 項目チェックリスト:
+ * 1. スキーマ違反 → 400 + validationErrors
+ * 2. target が VICTIM_ALLOWLIST に不在 → 403 + _trace.victimNote
+ * 3. ECONNREFUSED → 502
+ * 4. timeoutMs 超過 → 504
+ * 5. NODE_ENV=production → 503 live_attack_disabled_in_production
+ * 6. 双方向 raw bytes (browserToOrchestrator + orchestratorToVictim) を独立キャプチャ
+ * 7. Host ヘッダが victim baseUrl から計算した値に強制上書き
+ * 8. attack_log には summary のみで raw bytes は含まれない (本テストでは attack_log 永続化は対象外、
+ *    レスポンス内に raw bytes を含むこと自体は許容。orchestrator は永続化しないことを type で保証)
+ * 9. _trace.mode === "live"
+ * 10. _trace.victimNote が設定されている
+ *
+ * モック方針: DESIGN/31 §11.2 に従い in-process `http.createServer` で victim を立てる。
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import { traceMiddleware } from "../middleware/trace-logger.js";
+import { productionGuard } from "../middleware/production-guard.js";
+import { orchestratorExecRoutes } from "../routes/orchestrator-exec.js";
+
+interface MockVictim {
+  port: number;
+  url: string;
+  receivedRequests: Array<{
+    method: string;
+    url: string;
+    headers: http.IncomingHttpHeaders;
+    body: string;
+  }>;
+  close: () => Promise<void>;
+}
+
+type VictimResponder = (req: {
+  method: string;
+  url: string;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}) => { status: number; headers?: Record<string, string>; body: string };
+
+async function startMockVictim(responder: VictimResponder): Promise<MockVictim> {
+  const received: MockVictim["receivedRequests"] = [];
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk: Buffer) => {
+      body += chunk.toString("utf8");
+    });
+    req.on("end", () => {
+      received.push({
+        method: req.method ?? "GET",
+        url: req.url ?? "/",
+        headers: req.headers,
+        body,
+      });
+      const reply = responder({
+        method: req.method ?? "GET",
+        url: req.url ?? "/",
+        headers: req.headers,
+        body,
+      });
+      const headers = reply.headers ?? { "content-type": "application/json" };
+      res.writeHead(reply.status, headers);
+      res.end(reply.body);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    port,
+    url: `http://127.0.0.1:${port}`,
+    receivedRequests: received,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+function createApp() {
+  const app = new Hono();
+  app.use("/api/*", traceMiddleware);
+  app.use("/api/orchestrator/*", productionGuard);
+  app.route("/api/orchestrator", orchestratorExecRoutes);
+  return app;
+}
+
+function buildRequest(overrides?: Record<string, unknown>) {
+  return {
+    scenarioId: "jwt-alg-none-test",
+    target: "victim-web",
+    request: {
+      method: "POST",
+      path: "/jwt/verify",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "TEST_FIXTURE_NOT_A_JWT" }),
+    },
+    ...overrides,
+  };
+}
+
+let mockVictim: MockVictim | null = null;
+
+beforeEach(() => {
+  // 各テスト開始時にクリーンな環境を保証
+  delete process.env.VICTIM_WEB_BASE_URL;
+  delete process.env.LIVE_ATTACK_PHASE;
+  delete process.env.NODE_ENV;
+});
+
+afterEach(async () => {
+  if (mockVictim) {
+    await mockVictim.close();
+    mockVictim = null;
+  }
+  delete process.env.VICTIM_WEB_BASE_URL;
+  delete process.env.LIVE_ATTACK_PHASE;
+  delete process.env.NODE_ENV;
+});
+
+describe("POST /api/orchestrator/exec — schema validation (item 1)", () => {
+  it("returns 400 + validationErrors when required field is missing", async () => {
+    const app = createApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ scenarioId: "x" }), // target / request 欠如
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { success: boolean; error: string; validationErrors?: unknown[] };
+    expect(json.success).toBe(false);
+    expect(json.error).toBe("schema_validation_failed");
+    expect(Array.isArray(json.validationErrors)).toBe(true);
+    expect(json.validationErrors!.length).toBeGreaterThan(0);
+  });
+
+  it("returns 400 invalid_json_body when body is not JSON", async () => {
+    const app = createApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json{",
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("invalid_json_body");
+  });
+});
+
+describe("POST /api/orchestrator/exec — VICTIM_ALLOWLIST (item 2)", () => {
+  it("returns 403 with _trace.victimNote when target is not in allowlist", async () => {
+    const app = createApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildRequest({ target: "victim-tls-proxy" })),
+    });
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as {
+      success: boolean;
+      error: string;
+      _trace?: { victimNote?: string };
+    };
+    expect(json.success).toBe(false);
+    expect(json.error).toBe("target_not_in_allowlist");
+    expect(json._trace?.victimNote).toBeDefined();
+    expect(typeof json._trace!.victimNote).toBe("string");
+  });
+});
+
+describe("POST /api/orchestrator/exec — connection failure (item 3)", () => {
+  it("returns 502 victim_unreachable when victim cannot be reached", async () => {
+    // 確実に閉じているポート (ephemeral 0 を一時的に開いて閉じる)
+    const dead = await startMockVictim(() => ({ status: 200, body: "{}" }));
+    const deadUrl = dead.url;
+    await dead.close();
+    process.env.VICTIM_WEB_BASE_URL = deadUrl;
+
+    const app = createApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildRequest({ timeoutMs: 1000 })),
+    });
+    expect(res.status).toBe(502);
+    const json = (await res.json()) as { success: boolean; error: string; detail?: string };
+    expect(json.success).toBe(false);
+    expect(json.error).toBe("victim_unreachable");
+    expect(typeof json.detail).toBe("string");
+  });
+});
+
+describe("POST /api/orchestrator/exec — timeout (item 4)", () => {
+  it("returns 504 victim_timeout with timeoutMs echoed back", async () => {
+    // 応答しない victim (response を保留)
+    const stalled = http.createServer((_req, _res) => {
+      // 応答しないまま接続維持
+    });
+    await new Promise<void>((resolve) => stalled.listen(0, "127.0.0.1", resolve));
+    const port = (stalled.address() as AddressInfo).port;
+    process.env.VICTIM_WEB_BASE_URL = `http://127.0.0.1:${port}`;
+
+    try {
+      const app = createApp();
+      const res = await app.request("/api/orchestrator/exec", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildRequest({ timeoutMs: 200 })),
+      });
+      expect(res.status).toBe(504);
+      const json = (await res.json()) as { error: string; timeoutMs: number };
+      expect(json.error).toBe("victim_timeout");
+      expect(json.timeoutMs).toBe(200);
+    } finally {
+      await new Promise<void>((resolve) => stalled.close(() => resolve()));
+    }
+  });
+});
+
+describe("POST /api/orchestrator/exec — production guard (item 5)", () => {
+  it("returns 503 live_attack_disabled_in_production when NODE_ENV=production", async () => {
+    process.env.NODE_ENV = "production";
+    const app = createApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildRequest()),
+    });
+    expect(res.status).toBe(503);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("live_attack_disabled_in_production");
+  });
+});
+
+describe("POST /api/orchestrator/exec — successful proxy (items 6-10)", () => {
+  beforeEach(async () => {
+    mockVictim = await startMockVictim((req) => {
+      // 受信リクエストを反射するシンプルな victim
+      return {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          ok: true,
+          receivedMethod: req.method,
+          receivedUrl: req.url,
+          receivedBody: req.body,
+        }),
+      };
+    });
+    process.env.VICTIM_WEB_BASE_URL = mockVictim.url;
+  });
+
+  it("captures rawExchange.browserToOrchestrator and orchestratorToVictim independently (item 6)", async () => {
+    const app = createApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildRequest()),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      success: boolean;
+      data: {
+        rawExchange: {
+          browserToOrchestrator: { request: { line: string }; response: { line: string } };
+          orchestratorToVictim: {
+            request: { line: string; headers: Record<string, string>; body: string | null };
+            response: { line: string; status: number };
+            targetResolvedTo: string;
+          };
+          elapsedMs: number;
+        };
+      };
+    };
+    expect(json.success).toBe(true);
+    const ex = json.data.rawExchange;
+    expect(ex.browserToOrchestrator.request.line).toContain("/api/orchestrator/exec");
+    expect(ex.orchestratorToVictim.request.line).toContain("/jwt/verify");
+    expect(ex.orchestratorToVictim.response.status).toBe(200);
+    expect(ex.orchestratorToVictim.targetResolvedTo).toBe(mockVictim!.url);
+    expect(typeof ex.elapsedMs).toBe("number");
+    expect(ex.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("forces Host header to victim host (item 7)", async () => {
+    const app = createApp();
+    await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(
+        buildRequest({
+          request: {
+            method: "POST",
+            path: "/jwt/verify",
+            // ブラウザ側が悪意ある Host を送っても orchestrator が上書きすべき
+            headers: { "Content-Type": "application/json", Host: "evil.example.com" },
+            body: JSON.stringify({ token: "TEST_FIXTURE_NOT_A_JWT" }),
+          },
+        }),
+      ),
+    });
+    // victim 側が受信したヘッダで確認
+    const received = mockVictim!.receivedRequests[0];
+    const expectedHost = `127.0.0.1:${mockVictim!.port}`;
+    expect(received.headers.host).toBe(expectedHost);
+    expect(received.headers.host).not.toBe("evil.example.com");
+  });
+
+  it("does not include attack_log persistence (raw bytes are response-only, item 8)", async () => {
+    // attack_log への永続化は本実装では未実装。レスポンス側に raw bytes が含まれるが、
+    // 永続層には書き込まれていないことを契約として確認する。
+    // (DESIGN/31 §6.4: in-memory のみ、永続化禁止)
+    const app = createApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildRequest()),
+    });
+    const json = (await res.json()) as {
+      data: {
+        // raw bytes は応答に含まれて良い (browser が visualize するため)
+        rawExchange: unknown;
+        // ただし永続化向けの logId 等のフィールドを追加していないことを確認
+        attackLogId?: number;
+      };
+    };
+    expect(json.data.rawExchange).toBeDefined();
+    expect("attackLogId" in json.data).toBe(false);
+  });
+
+  it("sets _trace.mode === \"live\" (item 9)", async () => {
+    const app = createApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildRequest()),
+    });
+    const json = (await res.json()) as { _trace?: { mode?: string } };
+    expect(json._trace?.mode).toBe("live");
+  });
+
+  it("sets _trace.victimNote (item 10)", async () => {
+    const app = createApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildRequest()),
+    });
+    const json = (await res.json()) as { _trace?: { victimNote?: string } };
+    expect(typeof json._trace?.victimNote).toBe("string");
+    expect(json._trace!.victimNote!.length).toBeGreaterThan(0);
+  });
+});
+
+describe("POST /api/orchestrator/exec — phase guard (additional)", () => {
+  it("returns 503 phase_not_reached for attacker-shell at default phase 1", async () => {
+    const app = createApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildRequest({ target: "attacker-shell" })),
+    });
+    expect(res.status).toBe(503);
+    const json = (await res.json()) as {
+      error: string;
+      requiredPhase: number;
+      currentPhase: number;
+    };
+    expect(json.error).toBe("phase_not_reached");
+    expect(json.requiredPhase).toBe(2);
+    expect(json.currentPhase).toBe(1);
+  });
+});

--- a/server/routes/orchestrator-exec.ts
+++ b/server/routes/orchestrator-exec.ts
@@ -32,34 +32,41 @@ import type {
 export const orchestratorExecRoutes = new Hono();
 
 // ── VICTIM_ALLOWLIST (DESIGN/31 §5.1) ─────────────────────────────────
-const VICTIM_ALLOWLIST: ReadonlyMap<VictimTarget, VictimEntry> = new Map([
-  [
-    "victim-web",
-    {
-      // docker compose 環境では `victim-web` の DNS、dev:no-docker 環境では localhost を解決する。
-      // VICTIM_WEB_BASE_URL は test 用 override のみ許可 (本番デプロイ時は使われない)。
-      baseUrl: process.env.VICTIM_WEB_BASE_URL ?? "http://localhost:4001",
-      network: "victim-net",
-      phaseAvailable: 1,
-    },
-  ],
-  [
-    "attacker-shell",
-    {
-      baseUrl: "exec://attacker-shell",
-      network: "victim-net",
-      phaseAvailable: 2, // Phase 1 では HTTP プロキシ未対応 (Phase 2 で docker exec 対応予定)
-    },
-  ],
-] as const);
+//
+// テスト容易性 (DESIGN/31 §11.2) のため、`baseUrl` と Phase ガードはリクエスト
+// ごとに環境変数を再評価する。これにより in-process モック victim を立て
+// `VICTIM_WEB_BASE_URL` を切り替えるテストが書ける。本番では環境変数は
+// 設定しないため挙動は実質変わらない。
+function getVictimAllowlist(): ReadonlyMap<VictimTarget, VictimEntry> {
+  return new Map<VictimTarget, VictimEntry>([
+    [
+      "victim-web",
+      {
+        // docker compose 環境では `victim-web` の DNS、dev:no-docker 環境では localhost を解決する。
+        // VICTIM_WEB_BASE_URL は test 用 override のみ許可 (本番デプロイ時は使われない)。
+        baseUrl: process.env.VICTIM_WEB_BASE_URL ?? "http://localhost:4001",
+        network: "victim-net",
+        phaseAvailable: 1,
+      },
+    ],
+    [
+      "attacker-shell",
+      {
+        baseUrl: "exec://attacker-shell",
+        network: "victim-net",
+        phaseAvailable: 2, // Phase 1 では HTTP プロキシ未対応 (Phase 2 で docker exec 対応予定)
+      },
+    ],
+  ]);
+}
 
 // ── Phase ガード ─────────────────────────────────────────────────────
-const CURRENT_PHASE = (() => {
+function getCurrentPhase(): 1 | 2 | 3 | 4 | 5 {
   const env = process.env.LIVE_ATTACK_PHASE;
   const parsed = env ? Number(env) : 1;
   if (![1, 2, 3, 4, 5].includes(parsed)) return 1;
   return parsed as 1 | 2 | 3 | 4 | 5;
-})();
+}
 
 // ── zod スキーマ (DESIGN/31 §3.1) ─────────────────────────────────────
 const HTTP_METHOD_VALUES = [
@@ -119,7 +126,7 @@ orchestratorExecRoutes.post("/exec", async (c) => {
   };
 
   // 2. VICTIM_ALLOWLIST 検証
-  const entry = VICTIM_ALLOWLIST.get(req.target);
+  const entry = getVictimAllowlist().get(req.target);
   if (!entry) {
     // セキュリティログ: 不在キーは URL 偽造試行の可能性。target 値はレスポンスに含めない (情報漏洩防止)
     console.warn(
@@ -140,13 +147,14 @@ orchestratorExecRoutes.post("/exec", async (c) => {
   }
 
   // 3. Phase ガード
-  if (entry.phaseAvailable > CURRENT_PHASE) {
+  const currentPhase = getCurrentPhase();
+  if (entry.phaseAvailable > currentPhase) {
     return c.json(
       {
         success: false,
         error: "phase_not_reached",
         requiredPhase: entry.phaseAvailable,
-        currentPhase: CURRENT_PHASE,
+        currentPhase,
       },
       503,
     );


### PR DESCRIPTION
## 概要 / Summary

Phase 1 の最終 PR。DESIGN/30 §7.2 (CI Docker) と DESIGN/31 §11 (orchestrator テスト要件) を実装に落として Phase 1 を完了させる。

## 関連 Issue / Linked issues

- closes Phase 1 portion of #8

## 変更点 / Changes

**新規ファイル**
- `server/__tests__/orchestrator-live.test.ts`: in-process `http.createServer` で victim をモックし、orchestrator/exec の契約を 12 test (DESIGN/31 §11 の 10 項目 + invalid_json + phase ガード) で検証

**既存ファイルへの拡張**
- `server/routes/orchestrator-exec.ts`: `VICTIM_ALLOWLIST` と `CURRENT_PHASE` をリクエスト時評価する getter (`getVictimAllowlist` / `getCurrentPhase`) に refactor。**テスト容易性のための変更で、本番挙動は同一** (process.env を参照するタイミングだけが変わる)
- `.github/workflows/ci.yml`: `docker-smoke` job を追加。`victim-web` image を build → `docker compose up` → healthcheck wait → `/health` と `/jwt/verify` (alg=none) の smoke check
- `package.json`: `test:live` スクリプト追加 (orchestrator-live.test.ts のみを実行)
- `CLAUDE.md`: DESIGN ⇄ 実装 対応表に CI Docker job と test ファイルを追加

## 設計判断 / Design decisions

- **完全な live integration test は Phase 3+ に延期**: DESIGN/30 §7.2 の `test:live` を **実 Docker victim 経由で** 走らせる完全な統合テストは、orchestrator も compose 化される Phase 3+ で追加予定。Phase 1 では `docker-smoke` job が image build + healthcheck + curl smoke までを守り、orchestrator/exec の契約は `orchestrator-live.test.ts` の in-process モックでカバーする (DESIGN/31 §11.2 のモック方針に準拠)。CI コメントに明記済
- **VICTIM_ALLOWLIST の refactor**: 元実装は module load 時に `process.env` を 1 度だけ評価していたため、テストで in-process モックへ向け直すには `vi.resetModules()` + dynamic import が必要だった。これを避けるため getter 関数に切り出し。Map allocation のオーバーヘッドはあるが educational tool としては無視できる

## テスト要件チェックリスト (DESIGN/31 §11.1)

- [x] スキーマ違反 (必須フィールド欠如) → 400 + `validationErrors`
- [x] `target` が VICTIM_ALLOWLIST に不在 → 403 + `_trace.victimNote` 設定
- [x] victim 未起動 (ECONNREFUSED) → 502 + `detail` 含む
- [x] `timeoutMs: 200` でタイムアウト → 504 + `timeoutMs` echo
- [x] `NODE_ENV=production` → 503 `live_attack_disabled_in_production`
- [x] 双方向 raw bytes (`browserToOrchestrator` + `orchestratorToVictim`) を独立キャプチャ
- [x] `Host` ヘッダが victim baseUrl 由来の値に強制上書き (悪意ある Host を送っても上書きされる)
- [x] `attack_log` には raw bytes を含めない (永続化対象外、レスポンスのみ)
- [x] `_trace.mode === "live"`
- [x] `_trace.victimNote` が設定されている

**追加テスト** (10 項目に加えて):
- [x] `invalid_json_body` ハンドリング
- [x] `attacker-shell` を Phase 1 で叩くと 503 `phase_not_reached`

## テスト方法 / How to test

**ローカル**
- [x] `npm run test:ci` 476 / 476 pass (PR-2 の 464 から +12)
- [x] `npm run test:live` で orchestrator-live.test.ts のみ実行
- [x] `npx tsc --noEmit` (client + server) エラー 0
- [x] 既存テストへの影響なし

**CI**
- `check (22)` / `check (24)`: 既存ジョブで `npm run test:ci` を実行
- `docker-smoke`: 新規ジョブで `victim-web` image build + healthcheck + curl smoke

## DESIGN ⇄ 実装 整合性

- [x] DESIGN/30 §7.2 (CI Docker) を実装
- [x] DESIGN/31 §11 (テスト要件 10 項目) を実装
- [x] CLAUDE.md DESIGN ⇄ 実装 対応表を更新

---

## live モード PR チェックリスト

> 本 PR は orchestrator/exec の契約と CI Docker 環境を扱う。RawHttpComposer / SequenceDiagramView 自体には変更がない。

### DESIGN/34 §3 チェックリスト

- [x] §3.1 隔離 — `docker-compose.yml` の `read_only` / `cap_drop: ALL` / `tmpfs` / `pids_limit` は CI でも適用される
- [x] §3.2 表示・文言 — UI 変更なし
- [x] §3.3 教育内容 — 変更なし
- [x] §3.4 ペイロード — テストは `eyJhbGciOiJub25lIn0.e30.` のみ。実用可能なトークンは生成しない
- [x] §3.5 ログ・デバッグ — `console.log` / `localStorage` 追加なし

### Docker 環境確認

- [x] CI の `docker-smoke` job が `docker compose up -d victim-web` → healthcheck → `/health` と `/jwt/verify` smoke を実行
- [x] tear down step で `docker compose down -v` 実行
- [ ] (Phase 3+) `npm run dev:no-docker` 廃止後の動作確認方法を別 PR で記載予定
- [x] (Phase 1-2 暫定) `internal: true` 無効化の根拠は `docker-compose.yml` のコメントに記載済 (PR-1 から維持)

### live UI 確認

UI に変更がないため N/A