### PR TITLE
feat: live attack Phase 2 PR-1 — oauth-state-csrf live 化 (PoC 第 2 号)

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -11,3 +11,7 @@ secret:
   # Test files contain stub credentials (e.g. TEST_PW) that are not real secrets.
   ignored-paths:
     - "server/__tests__/**"
+    # services/victim-web/ contains intentional weak secrets (e.g. WEAK_SECRET = "secret",
+    # vuln-code-* fixtures, demo OAuth client ids/passwords) used to demonstrate why
+    # the corresponding defense in server/routes/*.ts is necessary. These are not real credentials.
+    - "services/victim-web/**"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,7 @@ PR レビュー時の「仕様 ↔ 実装」往復に使う。Phase 2+ で新規
 | DESIGN/31 §8 (Production guard) | `server/middleware/production-guard.ts` | `NODE_ENV==="production"` で 503 |
 | DESIGN/32 §2 (services/victim-web 構造) | `services/victim-web/{package.json,tsconfig.json,Dockerfile,src/index.ts,src/routes/jwt-vuln.ts}` | 脆弱 victim アプリ |
 | DESIGN/32 §4.1 (JWT 脆弱エンドポイント) | `services/victim-web/src/routes/jwt-vuln.ts` | `POST /jwt/verify` (alg=none 受理) |
+| DESIGN/32 §4.4 (OAuth 脆弱エンドポイント) | `services/victim-web/src/routes/oauth-vuln.ts` | `GET /oauth/authorize` (state 未検証で code 発行) |
 | DESIGN/32 §6 (Dockerfile + compose 安全設定) | `services/victim-web/Dockerfile`, `docker-compose.yml` (victim-web セクション) | tmpfs / cap_drop / read_only |
 | DESIGN/33 §2 (RawHttpComposer) | `src/components/shared/RawHttpComposer.tsx`, `RawHttpComposer.css` (Headers / Body / Raw タブ) | 生 HTTP リクエスト編集 UI |
 | DESIGN/33 §3 (SequenceDiagramView) | `src/components/shared/SequenceDiagramView.tsx`, `SequenceDiagramView.css` | D3 SVG シーケンス図 + raw bytes ポップアップ |
@@ -175,9 +176,12 @@ PR レビュー時の「仕様 ↔ 実装」往復に使う。Phase 2+ で新規
 | DESIGN/34 §6 (PR テンプレート) | `.github/pull_request_template.md` | live モード PR チェックリスト |
 | DESIGN/30 §7.2 (CI Docker) | `.github/workflows/ci.yml` の `docker-smoke` job | victim-web image build + healthcheck + /jwt/verify smoke |
 | DESIGN/31 §11 (テスト要件) | `server/__tests__/orchestrator-live.test.ts` (12 tests = 10 spec + 2 extra) | スキーマ違反 / target 不在 / 502 / 504 / production / Host 強制 / mode / victimNote / phase ガード |
+| DESIGN/32 §8.1 (victim 単体テスト) | `services/victim-web/__tests__/oauth-vuln.test.ts` | state なし code 発行 / state echo / client_id 欠如 400 |
+| DESIGN/30 §5.3 (シナリオ e2e) | `server/__tests__/scenarios/oauth-state-csrf.test.ts` | orchestrator → victim-web で 200 / state echo / 3 段 AttackStep / 400 → blocked |
 | DESIGN/34 §4 (新規安全装置) | `victim-net: internal: true`, `productionGuard`, `Host` 強制上書き, `cap_drop`, `read_only`, `tmpfs` | OS レイヤ防御 |
 | DESIGN/30 §6.2 (`mode` フィールド) | `shared/api-types.ts` (`AttackScenarioMeta.mode`, `liveTemplate`) | live/narration 切替 |
 | DESIGN/30 §5.3 (Phase 2 PoC 第 1 号) | `src/components/auth/attacks/scenarios/jwt-scenarios.ts` (`jwt-alg-none` の `mode: "live"`) + `src/components/auth/JwtInspector.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |
+| DESIGN/30 §5.3 (Phase 2 PoC 第 2 号) | `src/components/auth/attacks/scenarios/oauth-scenarios.ts` (`oauth-state-csrf` の `mode: "live"`) + `src/components/auth/OAuthFlow.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |
 
 ## ロードマップ: 攻撃デモの live 化 (Phase 1-5, 約 11 週)
 

--- a/server/__tests__/scenarios/oauth-state-csrf.test.ts
+++ b/server/__tests__/scenarios/oauth-state-csrf.test.ts
@@ -1,0 +1,223 @@
+/**
+ * シナリオ固有 e2e テスト: oauth-state-csrf (Phase 2 PoC)
+ *
+ * orchestrator (server/routes/orchestrator-exec.ts) → 実 victim-web (services/victim-web)
+ * の経路で state パラメータ未検証脆弱性が成立することを検証する。
+ *
+ * orchestrator 基盤の挙動 (schema validation / VICTIM_ALLOWLIST / Host 強制 / production guard 等)
+ * は server/__tests__/orchestrator-live.test.ts でカバーされているため、本ファイルでは
+ * シナリオ固有の挙動 (脆弱パス / mitigation 観察) のみを対象とする。
+ *
+ * DESIGN/30 §5.3 / DESIGN/32 §4.4 に対応。
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Hono } from "hono";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import { getRequestListener } from "@hono/node-server";
+import { traceMiddleware } from "../../middleware/trace-logger.js";
+import { productionGuard } from "../../middleware/production-guard.js";
+import { orchestratorExecRoutes } from "../../routes/orchestrator-exec.js";
+import { oauthVulnRoutes } from "../../../services/victim-web/src/routes/oauth-vuln.js";
+
+interface VictimInstance {
+  url: string;
+  close: () => Promise<void>;
+}
+
+/** 実 victim-web の oauth-vuln ルートを in-process で起動。 */
+async function startVictimWeb(): Promise<VictimInstance> {
+  const app = new Hono();
+  app.route("/oauth", oauthVulnRoutes);
+  const handler = getRequestListener(app.fetch);
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+function createOrchestratorApp() {
+  const app = new Hono();
+  app.use("/api/*", traceMiddleware);
+  app.use("/api/orchestrator/*", productionGuard);
+  app.route("/api/orchestrator", orchestratorExecRoutes);
+  return app;
+}
+
+let victim: VictimInstance | null = null;
+
+beforeAll(async () => {
+  victim = await startVictimWeb();
+  process.env.VICTIM_WEB_BASE_URL = victim.url;
+  delete process.env.LIVE_ATTACK_PHASE;
+  delete process.env.NODE_ENV;
+});
+
+afterAll(async () => {
+  if (victim) {
+    await victim.close();
+    victim = null;
+  }
+  delete process.env.VICTIM_WEB_BASE_URL;
+});
+
+describe("Phase 2 PoC: oauth-state-csrf (orchestrator → victim-web)", () => {
+  it("state パラメータ無しの GET /oauth/authorize で 200 + 認可コードが返る (脆弱性 e2e)", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "oauth-state-csrf",
+        target: "victim-web",
+        request: {
+          method: "GET",
+          path: "/oauth/authorize?client_id=demo-app&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=read",
+          headers: { Accept: "application/json" },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      success: boolean;
+      data: {
+        outcome: "succeeded" | "blocked" | "error";
+        rawExchange: {
+          orchestratorToVictim: {
+            request: { line: string };
+            response: { status: number; body: string | null };
+            targetResolvedTo: string;
+          };
+        };
+        mode: string;
+      };
+    };
+
+    expect(json.success).toBe(true);
+    expect(json.data.outcome).toBe("succeeded");
+    expect(json.data.mode).toBe("live");
+
+    const ex = json.data.rawExchange.orchestratorToVictim;
+    expect(ex.request.line).toContain("GET /oauth/authorize");
+    expect(ex.response.status).toBe(200);
+    expect(ex.targetResolvedTo).toBe(victim!.url);
+
+    // victim 応答のボディに認可コードが含まれていることを確認 = 脆弱性が成立
+    const victimBody = JSON.parse(ex.response.body ?? "{}") as {
+      ok: boolean;
+      code: string;
+      state_received: string | null;
+    };
+    expect(victimBody.ok).toBe(true);
+    expect(victimBody.code).toMatch(/^vuln-code-/);
+    expect(victimBody.state_received).toBeNull();
+  });
+
+  it("state パラメータがあっても victim は同様に code を発行する (state 検証なし)", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "oauth-state-csrf",
+        target: "victim-web",
+        request: {
+          method: "GET",
+          path: "/oauth/authorize?client_id=demo-app&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=read&state=learner_supplied_state",
+          headers: { Accept: "application/json" },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      success: boolean;
+      data: {
+        outcome: "succeeded" | "blocked" | "error";
+        rawExchange: {
+          orchestratorToVictim: { response: { status: number; body: string | null } };
+        };
+      };
+    };
+    expect(json.success).toBe(true);
+    expect(json.data.outcome).toBe("succeeded");
+    const victimBody = JSON.parse(
+      json.data.rawExchange.orchestratorToVictim.response.body ?? "{}",
+    ) as { code: string; state_received: string | null };
+    expect(victimBody.code).toMatch(/^vuln-code-/);
+    // state は echo されるが検証は行われない
+    expect(victimBody.state_received).toBe("learner_supplied_state");
+  });
+
+  it("AttackStep が probe / exploit / verify の 3 段で生成される", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "oauth-state-csrf",
+        target: "victim-web",
+        request: {
+          method: "GET",
+          path: "/oauth/authorize?client_id=demo-app&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback",
+          headers: {},
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: { steps: Array<{ id: string; kind: string; status: string }> };
+    };
+    const steps = json.data.steps;
+    expect(steps).toHaveLength(3);
+    expect(steps[0].kind).toBe("probe");
+    expect(steps[1].kind).toBe("exploit");
+    expect(steps[2].kind).toBe("verify");
+    expect(steps[1].status).toBe("success");
+    expect(steps[0].id).toBe("oauth-state-csrf-probe");
+    expect(steps[1].id).toBe("oauth-state-csrf-exploit");
+    expect(steps[2].id).toBe("oauth-state-csrf-verify");
+  });
+
+  it("client_id / redirect_uri 欠如時は victim が 400 を返し outcome は blocked", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "oauth-state-csrf",
+        target: "victim-web",
+        request: {
+          method: "GET",
+          // client_id / redirect_uri を意図的に欠如
+          path: "/oauth/authorize?scope=read",
+          headers: {},
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: {
+        outcome: "succeeded" | "blocked" | "error";
+        rawExchange: {
+          orchestratorToVictim: { response: { status: number } };
+        };
+        steps: Array<{ kind: string; status: string }>;
+      };
+    };
+    // victim が 400 を返したので、orchestrator は blocked と判定する
+    expect(json.data.rawExchange.orchestratorToVictim.response.status).toBe(400);
+    expect(json.data.outcome).toBe("succeeded"); // OrchestratorExecResponse 側は常に succeeded
+    // ステップ側で blocked が出ること
+    const blockedStep = json.data.steps.find((s) => s.kind === "blocked");
+    expect(blockedStep).toBeDefined();
+    expect(blockedStep!.status).toBe("blocked");
+  });
+});

--- a/services/victim-web/__tests__/oauth-vuln.test.ts
+++ b/services/victim-web/__tests__/oauth-vuln.test.ts
@@ -1,0 +1,85 @@
+/**
+ * victim-web 単体テスト: GET /oauth/authorize (oauth-state-csrf 脆弱エンドポイント)
+ *
+ * orchestrator を介さずに victim-web 単体の脆弱性が成立することを直接確認する。
+ * orchestrator 経由の e2e は server/__tests__/scenarios/oauth-state-csrf.test.ts で別途検証する。
+ *
+ * DESIGN/32 §4.4 / §8.1 (必須テスト): "GET /oauth/authorize — state なしで認可コードが発行されること"
+ */
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { oauthVulnRoutes } from "../src/routes/oauth-vuln.js";
+
+function createApp() {
+  const app = new Hono();
+  app.route("/oauth", oauthVulnRoutes);
+  return app;
+}
+
+describe("victim-web: GET /oauth/authorize (CWE-352 oauth-state-csrf)", () => {
+  it("state パラメータ無しで 200 + 認可コードを発行する (脆弱性の核心)", async () => {
+    const app = createApp();
+    const res = await app.request(
+      "/oauth/authorize?client_id=demo-app&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=read",
+      { method: "GET" },
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      ok: boolean;
+      code: string;
+      state_received: string | null;
+      note?: string;
+    };
+    expect(json.ok).toBe(true);
+    expect(typeof json.code).toBe("string");
+    expect(json.code).toMatch(/^vuln-code-/);
+    // state なしでも認可コードが発行される = 脆弱性が成立している
+    expect(json.state_received).toBeNull();
+    expect(json.note).toContain("CWE-352");
+  });
+
+  it("state パラメータあり/なし で挙動が変わらないこと (state は単に echo される)", async () => {
+    const app = createApp();
+    const resWith = await app.request(
+      "/oauth/authorize?client_id=demo-app&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&state=abc123",
+      { method: "GET" },
+    );
+    const resWithout = await app.request(
+      "/oauth/authorize?client_id=demo-app&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback",
+      { method: "GET" },
+    );
+    expect(resWith.status).toBe(200);
+    expect(resWithout.status).toBe(200);
+    const jsonWith = (await resWith.json()) as { code: string; state_received: string | null };
+    const jsonWithout = (await resWithout.json()) as { code: string; state_received: string | null };
+    // state 値を検証していないため、両方とも認可コードが発行される
+    expect(typeof jsonWith.code).toBe("string");
+    expect(typeof jsonWithout.code).toBe("string");
+    expect(jsonWith.state_received).toBe("abc123");
+    expect(jsonWithout.state_received).toBeNull();
+  });
+
+  it("client_id 欠如時は 400 を返す (最小バリデーション)", async () => {
+    const app = createApp();
+    const res = await app.request(
+      "/oauth/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback",
+      { method: "GET" },
+    );
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { ok: boolean; error: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("client_id");
+  });
+
+  it("redirect_uri 欠如時は 400 を返す", async () => {
+    const app = createApp();
+    const res = await app.request(
+      "/oauth/authorize?client_id=demo-app",
+      { method: "GET" },
+    );
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { ok: boolean; error: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("redirect_uri");
+  });
+});

--- a/services/victim-web/src/index.ts
+++ b/services/victim-web/src/index.ts
@@ -15,6 +15,7 @@
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import { jwtVulnRoutes } from "./routes/jwt-vuln.js";
+import { oauthVulnRoutes } from "./routes/oauth-vuln.js";
 
 const app = new Hono();
 
@@ -23,6 +24,7 @@ app.get("/health", (c) =>
 );
 
 app.route("/jwt", jwtVulnRoutes);
+app.route("/oauth", oauthVulnRoutes);
 
 // PORT は docker container 環境用 (compose で PORT=4001 を渡す)。
 // host で `dev:no-docker` を実行すると vite が PORT=3000 を環境にセットするため、

--- a/services/victim-web/src/routes/oauth-vuln.ts
+++ b/services/victim-web/src/routes/oauth-vuln.ts
@@ -1,0 +1,68 @@
+/**
+ * 脆弱エンドポイント: OAuth 2.0 (state CSRF)
+ *
+ * 【教育目的専用】
+ * このファイルは OSI 参照アプリの教材機能として、
+ * victim-net 内の固定シードデータに対する概念実証を提供します。
+ *
+ * - 外部ネットワークへのリクエストは行いません
+ * - 実 CVE のエクスプロイトコードは含みません
+ * - victim-net 外での動作は想定していません
+ *
+ * 対応 CWE: CWE-352 (state CSRF)
+ * 堅牢実装: server/routes/oauth-sim.ts (state 必須検証)
+ * 関連設計書: DESIGN/04-safety-guardrails.md, DESIGN/32-victim-web-spec.md §4.4
+ */
+import { Hono } from "hono";
+
+export const oauthVulnRoutes = new Hono();
+
+/**
+ * 脆弱: state パラメータを一切検証せず認可コードを発行する。
+ * 学習者が state なしで GET /oauth/authorize を送ると 200 + code が返る (CWE-352)。
+ *
+ * 期待入力: GET /oauth/authorize?client_id=<id>&redirect_uri=<uri>[&scope=<scope>][&state=<state>]
+ * 期待挙動:
+ *   - state なし → 200 + 認可コード発行 (脆弱性の核心)
+ *   - state あり → 200 + 認可コード発行 (検証も無効化されているため state は単に echo)
+ *   - client_id / redirect_uri 欠如 → 400
+ *
+ * 堅牢実装 (server/routes/oauth-sim.ts) では state パラメータが必須であり、
+ * sessionStorage に保存した state と照合することで CSRF を防ぐ。
+ */
+oauthVulnRoutes.get("/authorize", (c) => {
+  const clientId = c.req.query("client_id") ?? "";
+  const redirectUri = c.req.query("redirect_uri") ?? "";
+  const scope = c.req.query("scope") ?? "read";
+  const state = c.req.query("state") ?? null;
+  const responseType = c.req.query("response_type") ?? "code";
+
+  if (!clientId || !redirectUri) {
+    return c.json(
+      { ok: false, error: "client_id and redirect_uri are required" },
+      400,
+    );
+  }
+
+  // ── 脆弱性の核心 ─────────────────────────────────────────────────
+  // state の存在チェックも sessionStorage との照合も行わない。
+  // state を完全に無視するため、攻撃者が被害者のコールバックに
+  // 攻撃者制御の認可コードを注入できる (CWE-352)。
+  // ───────────────────────────────────────────────────────────────
+
+  // 教材用認可コード — 外部に漏洩しても無害な固定パターンの code 値
+  const code = `vuln-code-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+
+  return c.json({
+    ok: true,
+    code,
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope,
+    response_type: responseType,
+    state_received: state, // null でも 200 を返す = 脆弱性
+    note: "authorization code issued without verifying state (CWE-352 vulnerable: state parameter not enforced)",
+  });
+});

--- a/src/components/auth/OAuthFlow.tsx
+++ b/src/components/auth/OAuthFlow.tsx
@@ -11,7 +11,7 @@ import ViewModeToggle from "../shared/ViewModeToggle";
 import AttackPanel from "../shared/AttackPanel";
 import { getViewMode } from "../../state/attack-state";
 import { oauthScenarios } from "./attacks/scenarios/oauth-scenarios";
-import type { AttackResult } from "../../../shared/api-types";
+import type { AttackResult, OrchestratorExecResponse } from "../../../shared/api-types";
 import "./OAuthFlow.css";
 
 const SCOPE = "oauth-flow";
@@ -349,6 +349,7 @@ export default function OAuthFlow() {
         <AttackPanel
           tabId="oauth"
           scenarios={oauthScenarios}
+          allowedTargets={["victim-web"]}
           onRunScenario={async (s) => {
             const suffix = s.id.replace(/^oauth-/, "");
             // E-2: 両モード並列実行のため body は不要 (空オブジェクト)
@@ -366,6 +367,46 @@ export default function OAuthFlow() {
                 steps: [],
                 summaryJa: res.error ?? "実行エラーが発生しました",
                 summary: res.error ?? "Execution error occurred",
+              };
+            }
+            return res.data;
+          }}
+          onRunLiveScenario={async (s, payload) => {
+            const res = await apiPost<OrchestratorExecResponse>(
+              "/api/orchestrator/exec",
+              {
+                scenarioId: s.id,
+                target: payload.target,
+                request: payload.request,
+              },
+              "attack-oauth"
+            );
+            if (!res.data) {
+              const errMsg = res.error ?? "Execution error";
+              const friendlyJa =
+                errMsg === "victim_unreachable"
+                  ? "victim-web が起動していません。docker compose up -d victim-web または npm run dev:victim を実行してください。"
+                  : errMsg === "live_attack_disabled_in_production"
+                  ? "live モードは production 環境では無効です。"
+                  : errMsg === "phase_not_reached"
+                  ? "このシナリオは現在の Phase ではまだ live 化されていません。"
+                  : `実行エラー: ${errMsg}`;
+              const friendlyEn =
+                errMsg === "victim_unreachable"
+                  ? "victim-web is not reachable. Start it with `docker compose up -d victim-web` or `npm run dev:victim`."
+                  : errMsg === "live_attack_disabled_in_production"
+                  ? "Live mode is disabled in production."
+                  : errMsg === "phase_not_reached"
+                  ? "This scenario is not yet live in the current phase."
+                  : `Execution error: ${errMsg}`;
+              return {
+                scenarioId: s.id,
+                outcome: "error" as const,
+                startedAt: Date.now(),
+                finishedAt: Date.now(),
+                steps: [],
+                summaryJa: friendlyJa,
+                summary: friendlyEn,
               };
             }
             return res.data;

--- a/src/components/auth/attacks/scenarios/oauth-scenarios.ts
+++ b/src/components/auth/attacks/scenarios/oauth-scenarios.ts
@@ -70,6 +70,18 @@ const authUrl = \`/api/oauth/authorize?client_id=demo-app&redirect_uri=\${redire
         kind: "defensive",
       },
     ],
+    // Phase 2 PoC: live attack 化された 2 件目のシナリオ。
+    // 学習者は state パラメータを付け外しして 200/400 の差異を観察できる。
+    mode: "live",
+    liveTemplate: {
+      target: "victim-web",
+      method: "GET",
+      // 注: state パラメータが意図的に省略されている。学習者は state を付与すると
+      // 攻撃が緩和される動作差異を観察できる (堅牢実装側 server/routes/oauth-sim.ts は
+      // state 必須なので 400 を返すが、victim-web は脆弱で state なしでも 200 を返す)。
+      path: "/oauth/authorize?client_id=demo-app&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth%2Foauth%2Fcallback&scope=read&response_type=code",
+      headers: { Accept: "application/json" },
+    },
   },
   {
     id: "oauth-redirect-uri-bypass",


### PR DESCRIPTION
## Summary

DESIGN/30 §5.3 の Phase 2 PoC 5 件のうち 2 件目 (oauth-state-csrf) を live 化。
Phase 1 PR-1〜3 で確立した orchestrator/exec + RawHttpComposer + Sequence 経路を
そのまま再利用し、victim-web 側に脆弱な GET /oauth/authorize を追加するだけで
学習者が実 HTTP で state 欠落 CSRF を検証できるようにする。

- 新規: `services/victim-web/src/routes/oauth-vuln.ts` — state 未検証で 200 + 認可コードを発行 (CWE-352)
- 配線: `oauth-scenarios.ts` の oauth-state-csrf に `mode: "live"` + `liveTemplate`、`OAuthFlow.tsx` に `onRunLiveScenario` + `allowedTargets={["victim-web"]}`
- テスト: victim 単体 (`services/victim-web/__tests__/oauth-vuln.test.ts` 4 件) + orchestrator → victim e2e (`server/__tests__/scenarios/oauth-state-csrf.test.ts` 4 件)
- 環境改善: `.gitguardian.yaml` に `services/victim-web/**` を ignored-paths 追加 (Phase 2+ で victim 側の固定 fixture が増える前提)
- ドキュメント: `CLAUDE.md` の DESIGN ⇄ 実装表に新規 3 ファイル + Phase 2 PoC 第 2 号エントリ

## 設計判断

- **テストファイル分割**: orchestrator-live.test.ts は基盤テスト専用に残置、シナリオ固有は `server/__tests__/scenarios/<id>.test.ts` で 1 シナリオ 1 ファイル、victim 単体は `services/victim-web/__tests__/<area>-vuln.test.ts` の 3 層構成。Phase 2-3 で 17 シナリオ追加予定なので分割の効果が大きい。
- **LIVE バッジは追加せず既存 4 箇所を再利用**: `feedback_live_badges` メモリの「煩い」に従い、新規バッジは導入しない方針を継続。
- **scenario の `mode` プロパティ**: jwt-alg-none と同じく既存の narration 用 `modes[]` (脆弱/防御 並列実行) は残置。`mode: "live"` フラグで RawHttpComposer 経路に切り替わる。
- **GitGuardian 拡張は本 PR 同梱**: 独立 PR にする価値は薄い (yaml 1 行) ので Phase 2 第 1 弾と同梱し、以降の Phase 2 PR でテンプレ化。

## Test plan
- [x] `npx vitest run services/victim-web/__tests__/oauth-vuln.test.ts` — 4/4 pass
- [x] `npx vitest run server/__tests__/scenarios/oauth-state-csrf.test.ts` — 4/4 pass
- [x] `npm run test:ci` — 35 files / 484 tests / 0 fail (回帰なし)
- [x] `npm run build` + `npx tsc --noEmit` — クリーン
- [x] `npm run dev:no-docker` 起動 → 認証タブ → OAuth → 攻撃者モード → state 欠落 CSRF (LIVE バッジ表示) → 送信 → `POST /api/orchestrator/exec → 200`、orchestrator が `localhost:4001` の victim に GET → 200 + `code: "vuln-code-..."` + `state_received: null` → 3 段 AttackStep (probe/exploit/verify) 全 SUCCESS、SequenceDiagramView SVG レンダリング確認

## ロールアウト

- Phase ガード: 既存 `LIVE_ATTACK_PHASE` (default 1) で `victim-web` は phase 1+ で利用可能、本 PR は新規 victim 追加なしのため変更不要
- Production guard: 既存の 503 (`live_attack_disabled_in_production`) がそのまま機能
- Docker: victim-web は既存コンテナを再利用、本 PR は image rebuild のみで反映 (`npm run victim:reset`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)