### PR TITLE
feat: live attack Phase 2 PR-2 — rbac-idor live 化 (PoC 第 3 号)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,7 @@ PR レビュー時の「仕様 ↔ 実装」往復に使う。Phase 2+ で新規
 | DESIGN/32 §2 (services/victim-web 構造) | `services/victim-web/{package.json,tsconfig.json,Dockerfile,src/index.ts,src/routes/jwt-vuln.ts}` | 脆弱 victim アプリ |
 | DESIGN/32 §4.1 (JWT 脆弱エンドポイント) | `services/victim-web/src/routes/jwt-vuln.ts` | `POST /jwt/verify` (alg=none 受理) |
 | DESIGN/32 §4.4 (OAuth 脆弱エンドポイント) | `services/victim-web/src/routes/oauth-vuln.ts` | `GET /oauth/authorize` (state 未検証で code 発行) |
+| DESIGN/32 §4.5 (RBAC 脆弱エンドポイント) | `services/victim-web/src/routes/rbac-vuln.ts` | `POST /rbac/users/profile` (owner_id チェックなしで全フィールド返却) |
 | DESIGN/32 §6 (Dockerfile + compose 安全設定) | `services/victim-web/Dockerfile`, `docker-compose.yml` (victim-web セクション) | tmpfs / cap_drop / read_only |
 | DESIGN/33 §2 (RawHttpComposer) | `src/components/shared/RawHttpComposer.tsx`, `RawHttpComposer.css` (Headers / Body / Raw タブ) | 生 HTTP リクエスト編集 UI |
 | DESIGN/33 §3 (SequenceDiagramView) | `src/components/shared/SequenceDiagramView.tsx`, `SequenceDiagramView.css` | D3 SVG シーケンス図 + raw bytes ポップアップ |
@@ -176,12 +177,13 @@ PR レビュー時の「仕様 ↔ 実装」往復に使う。Phase 2+ で新規
 | DESIGN/34 §6 (PR テンプレート) | `.github/pull_request_template.md` | live モード PR チェックリスト |
 | DESIGN/30 §7.2 (CI Docker) | `.github/workflows/ci.yml` の `docker-smoke` job | victim-web image build + healthcheck + /jwt/verify smoke |
 | DESIGN/31 §11 (テスト要件) | `server/__tests__/orchestrator-live.test.ts` (12 tests = 10 spec + 2 extra) | スキーマ違反 / target 不在 / 502 / 504 / production / Host 強制 / mode / victimNote / phase ガード |
-| DESIGN/32 §8.1 (victim 単体テスト) | `services/victim-web/__tests__/oauth-vuln.test.ts` | state なし code 発行 / state echo / client_id 欠如 400 |
-| DESIGN/30 §5.3 (シナリオ e2e) | `server/__tests__/scenarios/oauth-state-csrf.test.ts` | orchestrator → victim-web で 200 / state echo / 3 段 AttackStep / 400 → blocked |
+| DESIGN/32 §8.1 (victim 単体テスト) | `services/victim-web/__tests__/oauth-vuln.test.ts`, `services/victim-web/__tests__/rbac-vuln.test.ts` | OAuth: state なし code 発行 / state echo / client_id 欠如 400 ／ RBAC: victimId 任意改竄で 200 / 不在 id 404 / 型バリデーション 400 |
+| DESIGN/30 §5.3 (シナリオ e2e) | `server/__tests__/scenarios/oauth-state-csrf.test.ts`, `server/__tests__/scenarios/rbac-idor.test.ts` | OAuth: orchestrator → victim-web で 200 / state echo / 3 段 AttackStep / 400 → blocked ／ RBAC: 任意 id でフルレコード漏洩 / leakedFields / 3 段 AttackStep / victimId 欠如 → blocked |
 | DESIGN/34 §4 (新規安全装置) | `victim-net: internal: true`, `productionGuard`, `Host` 強制上書き, `cap_drop`, `read_only`, `tmpfs` | OS レイヤ防御 |
 | DESIGN/30 §6.2 (`mode` フィールド) | `shared/api-types.ts` (`AttackScenarioMeta.mode`, `liveTemplate`) | live/narration 切替 |
 | DESIGN/30 §5.3 (Phase 2 PoC 第 1 号) | `src/components/auth/attacks/scenarios/jwt-scenarios.ts` (`jwt-alg-none` の `mode: "live"`) + `src/components/auth/JwtInspector.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |
 | DESIGN/30 §5.3 (Phase 2 PoC 第 2 号) | `src/components/auth/attacks/scenarios/oauth-scenarios.ts` (`oauth-state-csrf` の `mode: "live"`) + `src/components/auth/OAuthFlow.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |
+| DESIGN/30 §5.3 (Phase 2 PoC 第 3 号) | `src/components/auth/attacks/scenarios/rbac-scenarios.ts` (`rbac-idor` の `mode: "live"`) + `src/components/auth/PermissionModel.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |
 
 ## ロードマップ: 攻撃デモの live 化 (Phase 1-5, 約 11 週)
 

--- a/server/__tests__/scenarios/rbac-idor.test.ts
+++ b/server/__tests__/scenarios/rbac-idor.test.ts
@@ -1,0 +1,223 @@
+/**
+ * シナリオ固有 e2e テスト: rbac-idor (Phase 2 PoC 第 3 号)
+ *
+ * orchestrator (server/routes/orchestrator-exec.ts) → 実 victim-web (services/victim-web)
+ * の経路で IDOR 脆弱性 (CWE-639) が成立することを検証する。
+ *
+ * orchestrator 基盤の挙動 (schema validation / VICTIM_ALLOWLIST / Host 強制 / production guard 等)
+ * は server/__tests__/orchestrator-live.test.ts でカバーされているため、本ファイルでは
+ * シナリオ固有の挙動 (脆弱パス / mitigation 観察) のみを対象とする。
+ *
+ * DESIGN/30 §5.3 / DESIGN/32 §4.5 に対応。
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Hono } from "hono";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import { getRequestListener } from "@hono/node-server";
+import { traceMiddleware } from "../../middleware/trace-logger.js";
+import { productionGuard } from "../../middleware/production-guard.js";
+import { orchestratorExecRoutes } from "../../routes/orchestrator-exec.js";
+import { rbacVulnRoutes } from "../../../services/victim-web/src/routes/rbac-vuln.js";
+
+interface VictimInstance {
+  url: string;
+  close: () => Promise<void>;
+}
+
+/** 実 victim-web の rbac-vuln ルートを in-process で起動。 */
+async function startVictimWeb(): Promise<VictimInstance> {
+  const app = new Hono();
+  app.route("/rbac", rbacVulnRoutes);
+  const handler = getRequestListener(app.fetch);
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+function createOrchestratorApp() {
+  const app = new Hono();
+  app.use("/api/*", traceMiddleware);
+  app.use("/api/orchestrator/*", productionGuard);
+  app.route("/api/orchestrator", orchestratorExecRoutes);
+  return app;
+}
+
+let victim: VictimInstance | null = null;
+
+beforeAll(async () => {
+  victim = await startVictimWeb();
+  process.env.VICTIM_WEB_BASE_URL = victim.url;
+  delete process.env.LIVE_ATTACK_PHASE;
+  delete process.env.NODE_ENV;
+});
+
+afterAll(async () => {
+  if (victim) {
+    await victim.close();
+    victim = null;
+  }
+  delete process.env.VICTIM_WEB_BASE_URL;
+});
+
+describe("Phase 2 PoC: rbac-idor (orchestrator → victim-web)", () => {
+  it("攻撃者 charlie (id=3) が victimId=1 (alice) を送ると 200 + alice のフルレコードが漏洩 (脆弱性 e2e)", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "rbac-idor",
+        target: "victim-web",
+        request: {
+          method: "POST",
+          path: "/rbac/users/profile",
+          headers: { "Content-Type": "application/json", Accept: "application/json" },
+          body: JSON.stringify({ victimId: 1 }),
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      success: boolean;
+      data: {
+        outcome: "succeeded" | "blocked" | "error";
+        rawExchange: {
+          orchestratorToVictim: {
+            request: { line: string };
+            response: { status: number; body: string | null };
+            targetResolvedTo: string;
+          };
+        };
+        mode: string;
+      };
+    };
+
+    expect(json.success).toBe(true);
+    expect(json.data.outcome).toBe("succeeded");
+    expect(json.data.mode).toBe("live");
+
+    const ex = json.data.rawExchange.orchestratorToVictim;
+    expect(ex.request.line).toContain("POST /rbac/users/profile");
+    expect(ex.response.status).toBe(200);
+    expect(ex.targetResolvedTo).toBe(victim!.url);
+
+    // victim 応答のボディに alice のフルレコードが含まれていることを確認 = 脆弱性が成立
+    const victimBody = JSON.parse(ex.response.body ?? "{}") as {
+      ok: boolean;
+      user: { id: number; username: string; email: string; role: string; ownerId: number };
+      leakedFields: string[];
+    };
+    expect(victimBody.ok).toBe(true);
+    expect(victimBody.user.id).toBe(1);
+    expect(victimBody.user.username).toBe("seed_alice");
+    expect(victimBody.user.email).toBe("alice@example.com");
+    expect(victimBody.user.ownerId).toBe(1);
+    // 攻撃者 charlie の id=3 と ownerId=1 が一致しないにも関わらず、データが返却されている
+    expect(victimBody.leakedFields).toEqual(
+      expect.arrayContaining(["id", "username", "email", "role", "ownerId"]),
+    );
+  });
+
+  it("victimId をどの id に書き換えても 200 が返る (admin=4 を含む — 所有権検証が無いことの確認)", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "rbac-idor",
+        target: "victim-web",
+        request: {
+          method: "POST",
+          path: "/rbac/users/profile",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ victimId: 4 }),
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: {
+        outcome: string;
+        rawExchange: { orchestratorToVictim: { response: { status: number; body: string | null } } };
+      };
+    };
+    expect(json.data.outcome).toBe("succeeded");
+    const victimBody = JSON.parse(
+      json.data.rawExchange.orchestratorToVictim.response.body ?? "{}",
+    ) as { user: { id: number; role: string } };
+    expect(victimBody.user.id).toBe(4);
+    expect(victimBody.user.role).toBe("admin"); // 管理者ロールも漏洩する
+  });
+
+  it("AttackStep が probe / exploit / verify の 3 段で生成される", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "rbac-idor",
+        target: "victim-web",
+        request: {
+          method: "POST",
+          path: "/rbac/users/profile",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ victimId: 2 }),
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: { steps: Array<{ id: string; kind: string; status: string }> };
+    };
+    const steps = json.data.steps;
+    expect(steps).toHaveLength(3);
+    expect(steps[0].kind).toBe("probe");
+    expect(steps[1].kind).toBe("exploit");
+    expect(steps[2].kind).toBe("verify");
+    expect(steps[1].status).toBe("success");
+    expect(steps[0].id).toBe("rbac-idor-probe");
+    expect(steps[1].id).toBe("rbac-idor-exploit");
+    expect(steps[2].id).toBe("rbac-idor-verify");
+  });
+
+  it("victimId 欠如時は victim が 400 を返し、ステップは blocked になる", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "rbac-idor",
+        target: "victim-web",
+        request: {
+          method: "POST",
+          path: "/rbac/users/profile",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: {
+        outcome: string;
+        rawExchange: { orchestratorToVictim: { response: { status: number } } };
+        steps: Array<{ kind: string; status: string }>;
+      };
+    };
+    // victim が 400 を返したので、orchestrator は blocked 系のステップを出す
+    expect(json.data.rawExchange.orchestratorToVictim.response.status).toBe(400);
+    expect(json.data.outcome).toBe("succeeded"); // OrchestratorExecResponse 側は常に succeeded
+    const blockedStep = json.data.steps.find((s) => s.kind === "blocked");
+    expect(blockedStep).toBeDefined();
+    expect(blockedStep!.status).toBe("blocked");
+  });
+});

--- a/services/victim-web/__tests__/rbac-vuln.test.ts
+++ b/services/victim-web/__tests__/rbac-vuln.test.ts
@@ -1,0 +1,114 @@
+/**
+ * victim-web 単体テスト: POST /rbac/users/profile (rbac-idor 脆弱エンドポイント)
+ *
+ * orchestrator を介さずに victim-web 単体の脆弱性が成立することを直接確認する。
+ * orchestrator 経由の e2e は server/__tests__/scenarios/rbac-idor.test.ts で別途検証する。
+ *
+ * DESIGN/32 §4.5 / §8.1 (Phase 2 PR-2 で追記): "POST /rbac/users/profile — owner_id チェックなしでフルレコードが返ること"
+ */
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { rbacVulnRoutes } from "../src/routes/rbac-vuln.js";
+
+function createApp() {
+  const app = new Hono();
+  app.route("/rbac", rbacVulnRoutes);
+  return app;
+}
+
+describe("victim-web: POST /rbac/users/profile (CWE-639 rbac-idor)", () => {
+  it("攻撃者 (charlie=3) が他ユーザー (alice=1) の id を送ると 200 + フルレコードを返す (脆弱性の核心)", async () => {
+    const app = createApp();
+    const res = await app.request("/rbac/users/profile", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ victimId: 1 }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      ok: boolean;
+      user: { id: number; username: string; email: string; role: string; ownerId: number };
+      leakedFields: string[];
+      note?: string;
+    };
+    expect(json.ok).toBe(true);
+    // owner_id チェックなしのため、攻撃者本人以外の全フィールドが漏洩する
+    expect(json.user.id).toBe(1);
+    expect(json.user.username).toBe("seed_alice");
+    expect(json.user.email).toBe("alice@example.com");
+    expect(json.user.role).toBe("viewer");
+    expect(json.leakedFields).toEqual(
+      expect.arrayContaining(["id", "username", "email", "role", "ownerId"]),
+    );
+    expect(json.note).toContain("CWE-639");
+  });
+
+  it("victimId をどの id に書き換えても 200 が返る (所有権検証が無いことの確認)", async () => {
+    const app = createApp();
+    const ids = [1, 2, 3, 4]; // alice / bob / charlie / admin
+    for (const id of ids) {
+      const res = await app.request("/rbac/users/profile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ victimId: id }),
+      });
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { ok: boolean; user: { id: number } };
+      expect(json.ok).toBe(true);
+      expect(json.user.id).toBe(id);
+    }
+  });
+
+  it("シードに存在しない id (例: 99) は 404 を返す (脆弱性は変わらないが exploit パスは空振り)", async () => {
+    const app = createApp();
+    const res = await app.request("/rbac/users/profile", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ victimId: 99 }),
+    });
+    expect(res.status).toBe(404);
+    const json = (await res.json()) as { ok: boolean; error: string; requestedVictimId: number };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("not found");
+    expect(json.requestedVictimId).toBe(99);
+  });
+
+  it("victimId 欠如時は 400 を返す (最小バリデーション)", async () => {
+    const app = createApp();
+    const res = await app.request("/rbac/users/profile", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { ok: boolean; error: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("victimId");
+  });
+
+  it("victimId が文字列の場合も 400 を返す (型バリデーション)", async () => {
+    const app = createApp();
+    const res = await app.request("/rbac/users/profile", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ victimId: "1" }),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { ok: boolean; error: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("integer");
+  });
+
+  it("invalid JSON body は 400 を返す", async () => {
+    const app = createApp();
+    const res = await app.request("/rbac/users/profile", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { ok: boolean; error: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toBe("invalid_json_body");
+  });
+});

--- a/services/victim-web/src/index.ts
+++ b/services/victim-web/src/index.ts
@@ -16,6 +16,7 @@ import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import { jwtVulnRoutes } from "./routes/jwt-vuln.js";
 import { oauthVulnRoutes } from "./routes/oauth-vuln.js";
+import { rbacVulnRoutes } from "./routes/rbac-vuln.js";
 
 const app = new Hono();
 
@@ -25,6 +26,7 @@ app.get("/health", (c) =>
 
 app.route("/jwt", jwtVulnRoutes);
 app.route("/oauth", oauthVulnRoutes);
+app.route("/rbac", rbacVulnRoutes);
 
 // PORT は docker container 環境用 (compose で PORT=4001 を渡す)。
 // host で `dev:no-docker` を実行すると vite が PORT=3000 を環境にセットするため、

--- a/services/victim-web/src/routes/rbac-vuln.ts
+++ b/services/victim-web/src/routes/rbac-vuln.ts
@@ -1,0 +1,92 @@
+/**
+ * 脆弱エンドポイント: RBAC IDOR (Insecure Direct Object Reference)
+ *
+ * 【教育目的専用】
+ * このファイルは OSI 参照アプリの教材機能として、
+ * victim-net 内の固定シードデータに対する概念実証を提供します。
+ *
+ * - 外部ネットワークへのリクエストは行いません
+ * - 実 CVE のエクスプロイトコードは含みません
+ * - victim-net 外での動作は想定していません
+ *
+ * 対応 CWE: CWE-639 (Authorization Bypass Through User-Controlled Key)
+ * 対応 CAPEC: CAPEC-77
+ * 堅牢実装: server/routes/rbac.ts (POST /api/rbac/attack/idor の defended パス: WHERE owner_id = ?)
+ * 関連設計書: DESIGN/04-safety-guardrails.md, DESIGN/32-victim-web-spec.md §4.5 (Phase 2 PR-2 で追記)
+ */
+import { Hono } from "hono";
+
+export const rbacVulnRoutes = new Hono();
+
+/**
+ * 教材用シードユーザー (server/routes/rbac.ts の SEED_USERS と意図的に整合させる)
+ *
+ * - charlie (id=3) が attacker、その他 3 ユーザー (alice / bob / admin) が victim 候補
+ * - 全フィールドが固定文字列で、外部に漏洩しても無害
+ */
+const SEED_USERS: Readonly<
+  Record<
+    number,
+    Readonly<{ id: number; username: string; email: string; role: string; ownerId: number }>
+  >
+> = {
+  1: { id: 1, username: "seed_alice", email: "alice@example.com", role: "viewer", ownerId: 1 },
+  2: { id: 2, username: "seed_bob", email: "bob@example.com", role: "editor", ownerId: 2 },
+  3: { id: 3, username: "attacker_charlie", email: "charlie@example.com", role: "viewer", ownerId: 3 },
+  4: { id: 4, username: "seed_admin", email: "admin@example.com", role: "admin", ownerId: 4 },
+};
+
+/**
+ * 脆弱: ユーザー制御の victimId をそのまま使用し、所有権チェックを行わずユーザー全列を返却。
+ * 学習者が POST /rbac/users/profile に他ユーザーの id を送ると 200 + フルレコードが返る (CWE-639)。
+ *
+ * 期待入力: POST /rbac/users/profile  body: { "victimId": <number> }
+ * 期待挙動:
+ *   - 既知シード id (1-4) → 200 + 当該ユーザーの全フィールド (脆弱性の核心)
+ *   - 未知 id (例: 99) → 404 + ok:false (DB 上不在のためエクスプロイトパスが空振り)
+ *   - victimId 欠如 / 数値以外 → 400
+ *
+ * 堅牢実装 (server/routes/rbac.ts の defended パス) では
+ *   SELECT ... WHERE id = ? AND owner_id = ?
+ * によって認証済みユーザー以外のレコードは 0 行となり 403 が返る。
+ */
+rbacVulnRoutes.post("/users/profile", async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ ok: false, error: "invalid_json_body" }, 400);
+  }
+
+  if (typeof body !== "object" || body === null) {
+    return c.json({ ok: false, error: "request body must be a JSON object" }, 400);
+  }
+
+  const victimIdRaw = (body as { victimId?: unknown }).victimId;
+  if (typeof victimIdRaw !== "number" || !Number.isInteger(victimIdRaw)) {
+    return c.json({ ok: false, error: "victimId is required and must be an integer" }, 400);
+  }
+
+  // ── 脆弱性の核心 ─────────────────────────────────────────────────
+  // owner_id チェックを一切行わず、victimId をそのまま id 検索のキーとして使用する。
+  // 攻撃者が認証済みかどうか、リソースの所有者かどうかは問われない (CWE-639)。
+  // ───────────────────────────────────────────────────────────────
+  const user = SEED_USERS[victimIdRaw as keyof typeof SEED_USERS];
+  if (!user) {
+    return c.json(
+      {
+        ok: false,
+        error: "user not found",
+        requestedVictimId: victimIdRaw,
+      },
+      404,
+    );
+  }
+
+  return c.json({
+    ok: true,
+    user,
+    leakedFields: Object.keys(user),
+    note: "user record returned without ownership check (CWE-639 vulnerable: missing WHERE owner_id check)",
+  });
+});

--- a/src/components/auth/PermissionModel.tsx
+++ b/src/components/auth/PermissionModel.tsx
@@ -8,7 +8,7 @@ import ViewModeToggle from "../shared/ViewModeToggle";
 import AttackPanel from "../shared/AttackPanel";
 import { getViewMode } from "../../state/attack-state";
 import { rbacScenarios } from "./attacks/scenarios/rbac-scenarios";
-import type { AttackResult, AttackScenarioMeta } from "../../../shared/api-types";
+import type { AttackResult, AttackScenarioMeta, OrchestratorExecResponse } from "../../../shared/api-types";
 import "./PermissionModel.css";
 
 const SCOPE = "rbac-check";
@@ -656,6 +656,7 @@ export default function PermissionModel() {
         <AttackPanel
           tabId="rbac"
           scenarios={rbacScenarios}
+          allowedTargets={["victim-web"]}
           onRunScenario={async (s: AttackScenarioMeta) => {
             const routeSuffix = ROUTE_BY_ID[s.id] ?? s.id.replace(/^rbac-/, "");
             const res = await apiPost<AttackResult>(
@@ -672,6 +673,46 @@ export default function PermissionModel() {
                 steps: [],
                 summaryJa: res.error ?? "実行エラー",
                 summary: res.error ?? "Execution error",
+              };
+            }
+            return res.data;
+          }}
+          onRunLiveScenario={async (s, payload) => {
+            const res = await apiPost<OrchestratorExecResponse>(
+              "/api/orchestrator/exec",
+              {
+                scenarioId: s.id,
+                target: payload.target,
+                request: payload.request,
+              },
+              "attack-rbac"
+            );
+            if (!res.data) {
+              const errMsg = res.error ?? "Execution error";
+              const friendlyJa =
+                errMsg === "victim_unreachable"
+                  ? "victim-web が起動していません。docker compose up -d victim-web または npm run dev:victim を実行してください。"
+                  : errMsg === "live_attack_disabled_in_production"
+                  ? "live モードは production 環境では無効です。"
+                  : errMsg === "phase_not_reached"
+                  ? "このシナリオは現在の Phase ではまだ live 化されていません。"
+                  : `実行エラー: ${errMsg}`;
+              const friendlyEn =
+                errMsg === "victim_unreachable"
+                  ? "victim-web is not reachable. Start it with `docker compose up -d victim-web` or `npm run dev:victim`."
+                  : errMsg === "live_attack_disabled_in_production"
+                  ? "Live mode is disabled in production."
+                  : errMsg === "phase_not_reached"
+                  ? "This scenario is not yet live in the current phase."
+                  : `Execution error: ${errMsg}`;
+              return {
+                scenarioId: s.id,
+                outcome: "error" as const,
+                startedAt: Date.now(),
+                finishedAt: Date.now(),
+                steps: [],
+                summaryJa: friendlyJa,
+                summary: friendlyEn,
               };
             }
             return res.data;

--- a/src/components/auth/attacks/scenarios/rbac-scenarios.ts
+++ b/src/components/auth/attacks/scenarios/rbac-scenarios.ts
@@ -85,6 +85,21 @@ app.get("/users/me", async (c) => {
         kind: "defensive",
       },
     ],
+    // Phase 2 PoC: live attack 化された 3 件目のシナリオ。
+    // 学習者は victimId を 1 (alice) / 2 (bob) / 4 (admin) に書き換えて、
+    // 攻撃者 charlie (id=3) として他ユーザーのフルレコードが返ることを観察できる。
+    // 堅牢実装側 (server/routes/rbac.ts の defended パス) は WHERE owner_id チェックで 403 を返す。
+    mode: "live",
+    liveTemplate: {
+      target: "victim-web",
+      method: "POST",
+      // 注: victimId が attacker (charlie=3) ではなく victim (alice=1) を指している。
+      // 学習者は victimId を 3 に戻すと「自分のデータ」、別の id にすると「他人のデータ」が
+      // どちらも 200 で返ることを観察し、所有権チェックの欠如を理解できる。
+      path: "/rbac/users/profile",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ victimId: 1 }),
+    },
   },
   {
     id: "rbac-horizontal-privilege-escalation",


### PR DESCRIPTION
## Summary

- CWE-639 (Insecure Direct Object Reference) を実 HTTP 経路で再現する PoC 第 3 号
- victim-web に `POST /rbac/users/profile` 脆弱エンドポイント追加 (owner_id チェックなしで全フィールド返却)
- 学習者は RawHttpComposer で `victimId` を 1/2/3/4 に書き換えて、攻撃者 charlie (id=3) として alice/bob/admin のフルレコードが漏洩することを観察できる

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `services/victim-web/src/routes/rbac-vuln.ts` (新) | 脆弱エンドポイント本体 (CWE-639) |
| `services/victim-web/src/index.ts` | rbac ルート登録 |
| `src/components/auth/attacks/scenarios/rbac-scenarios.ts` | `rbac-idor` に `mode: "live"` + `liveTemplate` |
| `src/components/auth/PermissionModel.tsx` | `onRunLiveScenario` 配線 + `allowedTargets=["victim-web"]` |
| `services/victim-web/__tests__/rbac-vuln.test.ts` (新) | victim 単体 6 tests |
| `server/__tests__/scenarios/rbac-idor.test.ts` (新) | e2e シナリオ 4 tests |
| `CLAUDE.md` | DESIGN ⇄ 実装対応表に DESIGN/32 §4.5 + Phase 2 PoC 第 3 号 行を追加 |

## 安全性 (live モード PR チェックリスト)

- [x] victim-web 内のシードデータのみ参照 (新規 SEED_USERS は固定 4 ユーザー、外部漏洩無害)
- [x] 外部ネットワークへのリクエスト無し (victim-net 内のみ)
- [x] 実 CVE のエクスプロイトコード無し (概念実証のみ)
- [x] `victim-net: internal: true` の隔離維持 (新サービス追加なし)
- [x] `VICTIM_ALLOWLIST` 拡張なし (既存 victim-web target を流用)
- [x] production guard 通過 (orchestrator-live.test.ts のカバー範囲内)

## Test plan

- [x] `npm run test:ci` — 全 494 tests pass (新規 10 tests 含む)
- [x] `npm run build` — Vite ビルド成功
- [x] `npm --workspace=@osi-ref/victim-web run build` — TypeScript 型チェック成功
- [x] preview server (`npm run dev:no-docker`) で手動検証:
  - 認証・認可 → アクセス制御 → 攻撃者モード → IDOR シナリオ選択
  - RawHttpComposer に template 自動投入 (target=victim-web, POST /rbac/users/profile, body=`{"victimId":1}`)
  - 「送信 (LIVE)」で 200 + alice (`seed_alice / alice@example.com / viewer`) の全フィールド漏洩を確認
  - 3 段 AttackStep (probe → exploit → verify) 全 SUCCESS
  - コンソールエラーなし

## ロードマップ進捗

Phase 2 PoC 5 件のうち 3 件完了 (jwt-alg-none / oauth-state-csrf / **rbac-idor**)。残り 2 件 = `session-fixation` / `mfa-otp-replay`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)