### PR TITLE
feat: live attack Phase 2 PR-3 — session-fixation live 化 (PoC 第 4 号)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,7 @@ PR レビュー時の「仕様 ↔ 実装」往復に使う。Phase 2+ で新規
 | DESIGN/32 §4.1 (JWT 脆弱エンドポイント) | `services/victim-web/src/routes/jwt-vuln.ts` | `POST /jwt/verify` (alg=none 受理) |
 | DESIGN/32 §4.4 (OAuth 脆弱エンドポイント) | `services/victim-web/src/routes/oauth-vuln.ts` | `GET /oauth/authorize` (state 未検証で code 発行) |
 | DESIGN/32 §4.5 (RBAC 脆弱エンドポイント) | `services/victim-web/src/routes/rbac-vuln.ts` | `POST /rbac/users/profile` (owner_id チェックなしで全フィールド返却) |
+| DESIGN/32 §4.6 (Session 脆弱エンドポイント) | `services/victim-web/src/routes/session-vuln.ts` | `POST /session/login` (ログイン後 SID を再生成せず Cookie の session_id をそのまま echo) |
 | DESIGN/32 §6 (Dockerfile + compose 安全設定) | `services/victim-web/Dockerfile`, `docker-compose.yml` (victim-web セクション) | tmpfs / cap_drop / read_only |
 | DESIGN/33 §2 (RawHttpComposer) | `src/components/shared/RawHttpComposer.tsx`, `RawHttpComposer.css` (Headers / Body / Raw タブ) | 生 HTTP リクエスト編集 UI |
 | DESIGN/33 §3 (SequenceDiagramView) | `src/components/shared/SequenceDiagramView.tsx`, `SequenceDiagramView.css` | D3 SVG シーケンス図 + raw bytes ポップアップ |
@@ -184,6 +185,7 @@ PR レビュー時の「仕様 ↔ 実装」往復に使う。Phase 2+ で新規
 | DESIGN/30 §5.3 (Phase 2 PoC 第 1 号) | `src/components/auth/attacks/scenarios/jwt-scenarios.ts` (`jwt-alg-none` の `mode: "live"`) + `src/components/auth/JwtInspector.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |
 | DESIGN/30 §5.3 (Phase 2 PoC 第 2 号) | `src/components/auth/attacks/scenarios/oauth-scenarios.ts` (`oauth-state-csrf` の `mode: "live"`) + `src/components/auth/OAuthFlow.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |
 | DESIGN/30 §5.3 (Phase 2 PoC 第 3 号) | `src/components/auth/attacks/scenarios/rbac-scenarios.ts` (`rbac-idor` の `mode: "live"`) + `src/components/auth/PermissionModel.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |
+| DESIGN/30 §5.3 (Phase 2 PoC 第 4 号) | `src/components/auth/attacks/scenarios/session-token-scenarios.ts` (`session-fixation` の `mode: "live"`) + `src/components/auth/AuthComparison.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |
 
 ## ロードマップ: 攻撃デモの live 化 (Phase 1-5, 約 11 週)
 

--- a/server/__tests__/scenarios/session-fixation.test.ts
+++ b/server/__tests__/scenarios/session-fixation.test.ts
@@ -1,0 +1,245 @@
+/**
+ * シナリオ固有 e2e テスト: session-fixation (Phase 2 PoC 第 4 号)
+ *
+ * orchestrator (server/routes/orchestrator-exec.ts) → 実 victim-web (services/victim-web)
+ * の経路で Session Fixation 脆弱性 (CWE-384) が成立することを検証する。
+ *
+ * orchestrator 基盤の挙動 (schema validation / VICTIM_ALLOWLIST / Host 強制 / production guard 等)
+ * は server/__tests__/orchestrator-live.test.ts でカバーされているため、本ファイルでは
+ * シナリオ固有の挙動 (脆弱パス / mitigation 観察) のみを対象とする。
+ *
+ * DESIGN/30 §5.3 / DESIGN/32 §4.6 に対応。
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Hono } from "hono";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import { getRequestListener } from "@hono/node-server";
+import { traceMiddleware } from "../../middleware/trace-logger.js";
+import { productionGuard } from "../../middleware/production-guard.js";
+import { orchestratorExecRoutes } from "../../routes/orchestrator-exec.js";
+import { sessionVulnRoutes } from "../../../services/victim-web/src/routes/session-vuln.js";
+
+interface VictimInstance {
+  url: string;
+  close: () => Promise<void>;
+}
+
+/** 実 victim-web の session-vuln ルートを in-process で起動。 */
+async function startVictimWeb(): Promise<VictimInstance> {
+  const app = new Hono();
+  app.route("/session", sessionVulnRoutes);
+  const handler = getRequestListener(app.fetch);
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+function createOrchestratorApp() {
+  const app = new Hono();
+  app.use("/api/*", traceMiddleware);
+  app.use("/api/orchestrator/*", productionGuard);
+  app.route("/api/orchestrator", orchestratorExecRoutes);
+  return app;
+}
+
+let victim: VictimInstance | null = null;
+
+beforeAll(async () => {
+  victim = await startVictimWeb();
+  process.env.VICTIM_WEB_BASE_URL = victim.url;
+  delete process.env.LIVE_ATTACK_PHASE;
+  delete process.env.NODE_ENV;
+});
+
+afterAll(async () => {
+  if (victim) {
+    await victim.close();
+    victim = null;
+  }
+  delete process.env.VICTIM_WEB_BASE_URL;
+});
+
+describe("Phase 2 PoC: session-fixation (orchestrator → victim-web)", () => {
+  it("攻撃者既知 SID を Cookie で送ると 200 + Set-Cookie / body.sessionId に同じ SID が echo される (脆弱性 e2e)", async () => {
+    const app = createOrchestratorApp();
+    const attackerKnownSid = "ATTACKER_KNOWN_SID_v1";
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "session-fixation",
+        target: "victim-web",
+        request: {
+          method: "POST",
+          path: "/session/login",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            Cookie: `session_id=${attackerKnownSid}`,
+          },
+          body: JSON.stringify({ username: "seed_alice" }),
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      success: boolean;
+      data: {
+        outcome: "succeeded" | "blocked" | "error";
+        rawExchange: {
+          orchestratorToVictim: {
+            request: { line: string };
+            response: { status: number; headers: Record<string, string>; body: string | null };
+            targetResolvedTo: string;
+          };
+        };
+        mode: string;
+      };
+    };
+
+    expect(json.success).toBe(true);
+    expect(json.data.outcome).toBe("succeeded");
+    expect(json.data.mode).toBe("live");
+
+    const ex = json.data.rawExchange.orchestratorToVictim;
+    expect(ex.request.line).toContain("POST /session/login");
+    expect(ex.response.status).toBe(200);
+    expect(ex.targetResolvedTo).toBe(victim!.url);
+
+    // Set-Cookie に同じ SID が echo されている = 脆弱性が orchestrator 経路で成立
+    const setCookie = ex.response.headers["set-cookie"] ?? "";
+    expect(setCookie).toContain(`session_id=${attackerKnownSid}`);
+
+    // body にも sessionId が echo され、sessionIdSource=reused-from-request-cookie を確認
+    const victimBody = JSON.parse(ex.response.body ?? "{}") as {
+      ok: boolean;
+      user: { id: number; username: string };
+      sessionId: string;
+      sessionIdSource: string;
+      sessionRegenerated: boolean;
+    };
+    expect(victimBody.ok).toBe(true);
+    expect(victimBody.user.username).toBe("seed_alice");
+    expect(victimBody.sessionId).toBe(attackerKnownSid);
+    expect(victimBody.sessionIdSource).toBe("reused-from-request-cookie");
+    expect(victimBody.sessionRegenerated).toBe(false);
+  });
+
+  it("どの username でも Cookie の SID が同じなら echo される (admin にも昇格可能であることの確認)", async () => {
+    const app = createOrchestratorApp();
+    const attackerKnownSid = "EVIL_SID_zzz";
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "session-fixation",
+        target: "victim-web",
+        request: {
+          method: "POST",
+          path: "/session/login",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${attackerKnownSid}`,
+          },
+          body: JSON.stringify({ username: "seed_admin" }),
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: {
+        outcome: string;
+        rawExchange: {
+          orchestratorToVictim: {
+            response: { status: number; body: string | null };
+          };
+        };
+      };
+    };
+    expect(json.data.outcome).toBe("succeeded");
+    const victimBody = JSON.parse(
+      json.data.rawExchange.orchestratorToVictim.response.body ?? "{}",
+    ) as { user: { id: number; username: string }; sessionId: string };
+    expect(victimBody.user.id).toBe(4);
+    expect(victimBody.user.username).toBe("seed_admin");
+    expect(victimBody.sessionId).toBe(attackerKnownSid);
+  });
+
+  it("AttackStep が probe / exploit / verify の 3 段で生成される", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "session-fixation",
+        target: "victim-web",
+        request: {
+          method: "POST",
+          path: "/session/login",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: "session_id=ATTACKER_KNOWN_SID_v1",
+          },
+          body: JSON.stringify({ username: "seed_bob" }),
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: { steps: Array<{ id: string; kind: string; status: string }> };
+    };
+    const steps = json.data.steps;
+    expect(steps).toHaveLength(3);
+    expect(steps[0].kind).toBe("probe");
+    expect(steps[1].kind).toBe("exploit");
+    expect(steps[2].kind).toBe("verify");
+    expect(steps[1].status).toBe("success");
+    expect(steps[0].id).toBe("session-fixation-probe");
+    expect(steps[1].id).toBe("session-fixation-exploit");
+    expect(steps[2].id).toBe("session-fixation-verify");
+  });
+
+  it("不在 username では victim が 401 を返し、ステップは blocked になる", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "session-fixation",
+        target: "victim-web",
+        request: {
+          method: "POST",
+          path: "/session/login",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: "session_id=ATTACKER_KNOWN_SID_v1",
+          },
+          body: JSON.stringify({ username: "ghost_user" }),
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: {
+        outcome: string;
+        rawExchange: { orchestratorToVictim: { response: { status: number } } };
+        steps: Array<{ kind: string; status: string }>;
+      };
+    };
+    // victim が 401 を返したので、orchestrator は blocked 系のステップを出す
+    expect(json.data.rawExchange.orchestratorToVictim.response.status).toBe(401);
+    expect(json.data.outcome).toBe("succeeded"); // OrchestratorExecResponse 側は常に succeeded
+    const blockedStep = json.data.steps.find((s) => s.kind === "blocked");
+    expect(blockedStep).toBeDefined();
+    expect(blockedStep!.status).toBe("blocked");
+  });
+});

--- a/services/victim-web/__tests__/session-vuln.test.ts
+++ b/services/victim-web/__tests__/session-vuln.test.ts
@@ -1,0 +1,143 @@
+/**
+ * victim-web 単体テスト: POST /session/login (session-fixation 脆弱エンドポイント)
+ *
+ * orchestrator を介さずに victim-web 単体の脆弱性が成立することを直接確認する。
+ * orchestrator 経由の e2e は server/__tests__/scenarios/session-fixation.test.ts で別途検証する。
+ *
+ * DESIGN/32 §4.6 / §8.1 (Phase 2 PR-3 で追記): "POST /session/login — Cookie の session_id が
+ * 認証成功後も再生成されず、Set-Cookie / body.sessionId に同じ値が echo されること"
+ */
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { sessionVulnRoutes } from "../src/routes/session-vuln.js";
+
+function createApp() {
+  const app = new Hono();
+  app.route("/session", sessionVulnRoutes);
+  return app;
+}
+
+describe("victim-web: POST /session/login (CWE-384 session-fixation)", () => {
+  it("攻撃者既知 SID を Cookie で送ると 200 + Set-Cookie に同じ SID が echo される (脆弱性の核心)", async () => {
+    const app = createApp();
+    const attackerKnownSid = "ATTACKER_KNOWN_SID_v1";
+    const res = await app.request("/session/login", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `session_id=${attackerKnownSid}`,
+      },
+      body: JSON.stringify({ username: "seed_alice" }),
+    });
+    expect(res.status).toBe(200);
+
+    // Set-Cookie ヘッダに同じ SID が echo されている = 脆弱性の核心
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`session_id=${attackerKnownSid}`);
+    expect(setCookie.toLowerCase()).toContain("httponly");
+
+    const json = (await res.json()) as {
+      ok: boolean;
+      user: { id: number; username: string };
+      sessionId: string;
+      sessionIdSource: string;
+      sessionRegenerated: boolean;
+      note?: string;
+    };
+    expect(json.ok).toBe(true);
+    expect(json.user.id).toBe(1);
+    expect(json.user.username).toBe("seed_alice");
+    expect(json.sessionId).toBe(attackerKnownSid);
+    expect(json.sessionIdSource).toBe("reused-from-request-cookie");
+    expect(json.sessionRegenerated).toBe(false);
+    expect(json.note).toContain("CWE-384");
+  });
+
+  it("Cookie の session_id をどの値に書き換えても 200 + Set-Cookie で echo される (SID 再生成欠如の確認)", async () => {
+    const app = createApp();
+    const sids = ["custom-sid-1", "evil-sid-abc", "FIXATION_ATTACKER_SID_v1"];
+    for (const sid of sids) {
+      const res = await app.request("/session/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: `session_id=${sid}`,
+        },
+        body: JSON.stringify({ username: "seed_bob" }),
+      });
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { ok: boolean; sessionId: string; user: { id: number } };
+      expect(json.ok).toBe(true);
+      expect(json.sessionId).toBe(sid);
+      expect(json.user.id).toBe(2);
+    }
+  });
+
+  it("Cookie が無い場合は 200 + 新規 SID を発行する (生成パスも動く)", async () => {
+    const app = createApp();
+    const res = await app.request("/session/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "seed_alice" }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      ok: boolean;
+      sessionId: string;
+      sessionIdSource: string;
+    };
+    expect(json.ok).toBe(true);
+    expect(json.sessionIdSource).toBe("newly-generated");
+    expect(json.sessionId).toMatch(/^VICTIM_FRESH_/);
+
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`session_id=${json.sessionId}`);
+  });
+
+  it("シードに存在しないユーザー名は 401 を返す", async () => {
+    const app = createApp();
+    const res = await app.request("/session/login", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: "session_id=does-not-matter",
+      },
+      body: JSON.stringify({ username: "ghost_user" }),
+    });
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as {
+      ok: boolean;
+      error: string;
+      requestedUsername: string;
+    };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("invalid credentials");
+    expect(json.requestedUsername).toBe("ghost_user");
+  });
+
+  it("username 欠如時は 400 を返す (最小バリデーション)", async () => {
+    const app = createApp();
+    const res = await app.request("/session/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { ok: boolean; error: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("username");
+  });
+
+  it("invalid JSON body は 400 を返す", async () => {
+    const app = createApp();
+    const res = await app.request("/session/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { ok: boolean; error: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toBe("invalid_json_body");
+  });
+});

--- a/services/victim-web/src/index.ts
+++ b/services/victim-web/src/index.ts
@@ -17,6 +17,7 @@ import { serve } from "@hono/node-server";
 import { jwtVulnRoutes } from "./routes/jwt-vuln.js";
 import { oauthVulnRoutes } from "./routes/oauth-vuln.js";
 import { rbacVulnRoutes } from "./routes/rbac-vuln.js";
+import { sessionVulnRoutes } from "./routes/session-vuln.js";
 
 const app = new Hono();
 
@@ -27,6 +28,7 @@ app.get("/health", (c) =>
 app.route("/jwt", jwtVulnRoutes);
 app.route("/oauth", oauthVulnRoutes);
 app.route("/rbac", rbacVulnRoutes);
+app.route("/session", sessionVulnRoutes);
 
 // PORT は docker container 環境用 (compose で PORT=4001 を渡す)。
 // host で `dev:no-docker` を実行すると vite が PORT=3000 を環境にセットするため、

--- a/services/victim-web/src/routes/session-vuln.ts
+++ b/services/victim-web/src/routes/session-vuln.ts
@@ -1,0 +1,113 @@
+/**
+ * 脆弱エンドポイント: Session Fixation (CWE-384)
+ *
+ * 【教育目的専用】
+ * このファイルは OSI 参照アプリの教材機能として、
+ * victim-net 内の固定シードデータに対する概念実証を提供します。
+ *
+ * - 外部ネットワークへのリクエストは行いません
+ * - 実 CVE のエクスプロイトコードは含みません
+ * - victim-net 外での動作は想定していません
+ *
+ * 対応 CWE: CWE-384 (Session Fixation)
+ * 対応 CAPEC: CAPEC-61
+ * 堅牢実装: server/routes/session-auth.ts (POST /api/session/login の uuidv4() 再生成パス)
+ * 関連設計書: DESIGN/04-safety-guardrails.md, DESIGN/32-victim-web-spec.md §4.6 (Phase 2 PR-3 で追記)
+ */
+import { Hono } from "hono";
+import { getCookie, setCookie } from "hono/cookie";
+
+export const sessionVulnRoutes = new Hono();
+
+/**
+ * 教材用シードユーザー (server/db/schema.ts の seed と意図的に整合させる)
+ *
+ * - charlie (id=3) が attacker、その他 3 ユーザー (alice / bob / admin) が victim 候補
+ * - パスワード検証は教材簡素化のため省略 (victim 単体で再現できる脆弱性核心は SID 再生成欠如)
+ */
+const SEED_USERS: Readonly<
+  Record<string, Readonly<{ id: number; username: string }>>
+> = {
+  seed_alice: { id: 1, username: "seed_alice" },
+  seed_bob: { id: 2, username: "seed_bob" },
+  attacker_charlie: { id: 3, username: "attacker_charlie" },
+  seed_admin: { id: 4, username: "seed_admin" },
+};
+
+/**
+ * 脆弱: ログインリクエストに `Cookie: session_id=...` が含まれていれば、
+ * 認証成功後もその SID をそのまま再利用 (Set-Cookie で同じ値を echo)。
+ *
+ * 学習者が事前既知 SID (例: ATTACKER_KNOWN_SID_v1) を Cookie で送ると、
+ * レスポンスの Set-Cookie / body.sessionId に同じ値が入って返り、
+ * 「ログイン後に SID が再生成されない = 攻撃者の事前知識がそのまま有効」を観察できる (CWE-384)。
+ *
+ * 期待入力: POST /session/login
+ *           headers: { Cookie?: "session_id=<attacker-known-sid>" }
+ *           body:    { "username": "<seed_alice|seed_bob|seed_admin|attacker_charlie>" }
+ * 期待挙動:
+ *   - 既知ユーザー + Cookie あり → 200 + Set-Cookie に同じ SID を echo (脆弱性の核心)
+ *   - 既知ユーザー + Cookie なし → 200 + 新規 SID を Set-Cookie で発行 (生成パスも動く)
+ *   - 未知ユーザー → 401
+ *   - body 欠如 / 型違反 → 400
+ *   - invalid JSON body → 400
+ *
+ * 堅牢実装 (server/routes/session-auth.ts) では認証成功時に必ず uuidv4() で
+ * 新規 SID を発行するため、攻撃者の事前 SID は無効化される。
+ */
+sessionVulnRoutes.post("/login", async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ ok: false, error: "invalid_json_body" }, 400);
+  }
+
+  if (typeof body !== "object" || body === null) {
+    return c.json({ ok: false, error: "request body must be a JSON object" }, 400);
+  }
+
+  const usernameRaw = (body as { username?: unknown }).username;
+  if (typeof usernameRaw !== "string" || usernameRaw.length === 0) {
+    return c.json(
+      { ok: false, error: "username is required and must be a non-empty string" },
+      400,
+    );
+  }
+
+  const user = SEED_USERS[usernameRaw];
+  if (!user) {
+    return c.json(
+      { ok: false, error: "invalid credentials", requestedUsername: usernameRaw },
+      401,
+    );
+  }
+
+  // ── 脆弱性の核心 ─────────────────────────────────────────────────
+  // リクエスト Cookie の session_id が存在すれば、認証後もそれをそのまま再利用する。
+  // 「ログイン後の SID 再生成」をスキップするため、攻撃者が事前に知っている SID が
+  // 認証済みセッションに紐付き、Set-Cookie で echo される (CWE-384)。
+  // ───────────────────────────────────────────────────────────────
+  const reusedSid = getCookie(c, "session_id");
+  const sessionId = reusedSid ?? `VICTIM_FRESH_${Date.now().toString(36)}`;
+  const sessionIdSource: "reused-from-request-cookie" | "newly-generated" =
+    reusedSid ? "reused-from-request-cookie" : "newly-generated";
+
+  // Set-Cookie に同じ SID を載せる (HttpOnly のみ、Secure は教材なので付けない)
+  setCookie(c, "session_id", sessionId, {
+    httpOnly: true,
+    path: "/",
+  });
+
+  return c.json({
+    ok: true,
+    user,
+    sessionId,
+    sessionIdSource,
+    sessionRegenerated: false,
+    note:
+      sessionIdSource === "reused-from-request-cookie"
+        ? "session ID NOT regenerated after authentication (CWE-384 vulnerable: pre-known SID reused)"
+        : "session ID generated for the first time, but no rotation occurs on subsequent logins (CWE-384 vulnerable behavior)",
+  });
+});

--- a/src/components/auth/AuthComparison.tsx
+++ b/src/components/auth/AuthComparison.tsx
@@ -9,7 +9,7 @@ import ViewModeToggle from "../shared/ViewModeToggle";
 import AttackPanel from "../shared/AttackPanel";
 import { getViewMode } from "../../state/attack-state";
 import { sessionTokenScenarios } from "./attacks/scenarios/session-token-scenarios";
-import type { AttackResult } from "../../../shared/api-types";
+import type { AttackResult, OrchestratorExecResponse } from "../../../shared/api-types";
 import "./AuthComparison.css";
 
 const SCOPE_SESSION = "session-auth";
@@ -378,6 +378,7 @@ export default function AuthComparison() {
         <AttackPanel
           tabId="session-vs-token"
           scenarios={sessionTokenScenarios}
+          allowedTargets={["victim-web"]}
           onRunScenario={async (s) => {
             const route = ROUTE_BY_ID[s.id];
             if (!route) {
@@ -405,6 +406,46 @@ export default function AuthComparison() {
                 steps: [],
                 summaryJa: res.error ?? "実行エラー",
                 summary: res.error ?? "Execution error",
+              };
+            }
+            return res.data;
+          }}
+          onRunLiveScenario={async (s, payload) => {
+            const res = await apiPost<OrchestratorExecResponse>(
+              "/api/orchestrator/exec",
+              {
+                scenarioId: s.id,
+                target: payload.target,
+                request: payload.request,
+              },
+              "attack-session-vs-token"
+            );
+            if (!res.data) {
+              const errMsg = res.error ?? "Execution error";
+              const friendlyJa =
+                errMsg === "victim_unreachable"
+                  ? "victim-web が起動していません。docker compose up -d victim-web または npm run dev:victim を実行してください。"
+                  : errMsg === "live_attack_disabled_in_production"
+                  ? "live モードは production 環境では無効です。"
+                  : errMsg === "phase_not_reached"
+                  ? "このシナリオは現在の Phase ではまだ live 化されていません。"
+                  : `実行エラー: ${errMsg}`;
+              const friendlyEn =
+                errMsg === "victim_unreachable"
+                  ? "victim-web is not reachable. Start it with `docker compose up -d victim-web` or `npm run dev:victim`."
+                  : errMsg === "live_attack_disabled_in_production"
+                  ? "Live mode is disabled in production."
+                  : errMsg === "phase_not_reached"
+                  ? "This scenario is not yet live in the current phase."
+                  : `Execution error: ${errMsg}`;
+              return {
+                scenarioId: s.id,
+                outcome: "error" as const,
+                startedAt: Date.now(),
+                finishedAt: Date.now(),
+                steps: [],
+                summaryJa: friendlyJa,
+                summary: friendlyEn,
               };
             }
             return res.data;

--- a/src/components/auth/attacks/scenarios/session-token-scenarios.ts
+++ b/src/components/auth/attacks/scenarios/session-token-scenarios.ts
@@ -88,6 +88,25 @@ app.post("/login", async (c) => {
         kind: "defensive",
       },
     ],
+    // Phase 2 PoC: live attack 化された 4 件目のシナリオ。
+    // 学習者は Cookie の `session_id=ATTACKER_KNOWN_SID_v1` を任意値に書き換えて、
+    // vulnerable victim が認証成功後も同じ SID を Set-Cookie で echo することを観察できる。
+    // 堅牢実装側 (server/routes/session-auth.ts) では認証成功時に uuidv4() で新規 SID を発行する。
+    mode: "live",
+    liveTemplate: {
+      target: "victim-web",
+      method: "POST",
+      path: "/session/login",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        // 攻撃者が事前に知る固定 SID。Cookie ヘッダで送ると、vulnerable victim は
+        // ログイン成功後もこの SID を再利用 (Set-Cookie で echo) するため、
+        // 攻撃者が同じ SID で被害者になりすませる状態が成立する。
+        Cookie: "session_id=ATTACKER_KNOWN_SID_v1",
+      },
+      body: JSON.stringify({ username: "seed_alice" }),
+    },
   },
   {
     id: "session-xss-cookie-theft",


### PR DESCRIPTION
## Summary

- CWE-384 (Session Fixation) を実 HTTP 経路で live 化 — Phase 2 PoC 第 4 号 (5 件中 4 件目)
- 学習者は Cookie の `session_id=ATTACKER_KNOWN_SID_v1` を任意値に書き換え、orchestrator → victim-web → 認証成功後も**同じ SID が Set-Cookie で echo** される (CWE-384 の核心 = ログイン後 SID 再生成欠如) を観察できる
- PR #14 / #17 / #18 と同じ標準パターン: 7 ファイル変更 (victim ルート + index 登録 + scenarios + コンポーネント配線 + 2 テスト + CLAUDE.md)、テスト 10 件 (victim 単体 6 + e2e 4) 全 pass

## 変更ファイル

| File | Role |
|---|---|
| `services/victim-web/src/routes/session-vuln.ts` (新) | `POST /session/login` — Cookie の session_id を再利用して Set-Cookie で echo |
| `services/victim-web/src/index.ts` | `app.route("/session", sessionVulnRoutes)` 登録 |
| `src/components/auth/attacks/scenarios/session-token-scenarios.ts` | `session-fixation` に `mode: "live"` + `liveTemplate` 追加 |
| `src/components/auth/AuthComparison.tsx` | `onRunLiveScenario` 配線 + `allowedTargets={["victim-web"]}` |
| `services/victim-web/__tests__/session-vuln.test.ts` (新) | victim 単体 6 件 (脆弱性核心 / 任意 SID echo / 新規発行 / 401 / 400×2) |
| `server/__tests__/scenarios/session-fixation.test.ts` (新) | e2e 4 件 (orchestrator 経由 SID echo / admin 昇格 / 3 段 AttackStep / blocked) |
| `CLAUDE.md` | DESIGN/32 §4.6 + Phase 2 PoC 第 4 号 行を対応表に追加 |

## 脆弱性の核心

```
POST /session/login HTTP/1.1
Cookie: session_id=ATTACKER_KNOWN_SID_v1
Content-Type: application/json

{"username":"seed_alice"}
```

```
HTTP/1.1 200 OK
Set-Cookie: session_id=ATTACKER_KNOWN_SID_v1; Path=/; HttpOnly  ← 同じ SID を echo
Content-Type: application/json

{"ok":true,"user":{"id":1,"username":"seed_alice"},
 "sessionId":"ATTACKER_KNOWN_SID_v1","sessionIdSource":"reused-from-request-cookie",
 "sessionRegenerated":false,
 "note":"session ID NOT regenerated after authentication (CWE-384 vulnerable: pre-known SID reused)"}
```

堅牢実装 (`server/routes/session-auth.ts` の `POST /api/session/login`) では認証成功時に `uuidv4()` で新 SID を発行するため、攻撃者の事前 SID は無効化される。

## Test plan

- [x] `npx vitest run services/victim-web/__tests__/session-vuln.test.ts` — 6/6 pass
- [x] `npx vitest run server/__tests__/scenarios/session-fixation.test.ts` — 4/4 pass
- [x] `npx tsc --noEmit -p tsconfig.json` — 0 errors
- [x] `npx tsc --noEmit -p services/victim-web/tsconfig.json` — 0 errors
- [x] `npm run dev:no-docker` 起動 + ブラウザで認証・認可 → セッション vs トークン → 攻撃者モード → セッション固定攻撃 → LIVE バッジ → 送信 (LIVE) で「攻撃成立」+ probe/exploit/verify 全 SUCCESS を確認、console error 0 件
- [x] `curl` で victim 単体 (`localhost:4001/session/login`) と orchestrator 経由 (`localhost:3001/api/orchestrator/exec`) 両方で SID echo を確認

## Phase 2 進捗

PoC 5 件中 4 件完了 — 残り 1 件 (`mfa-otp-replay`)。標準パターンが安定したため次 PR-4 も同形で進められる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)