### PR TITLE
feat: live attack Phase 2 PR-4 — mfa-otp-replay live 化 + AttackStoryboard 基盤 (Phase 2 完結)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,15 @@ PR レビュー時の「仕様 ↔ 実装」往復に使う。Phase 2+ で新規
 | DESIGN/30 §5.3 (Phase 2 PoC 第 2 号) | `src/components/auth/attacks/scenarios/oauth-scenarios.ts` (`oauth-state-csrf` の `mode: "live"`) + `src/components/auth/OAuthFlow.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |
 | DESIGN/30 §5.3 (Phase 2 PoC 第 3 号) | `src/components/auth/attacks/scenarios/rbac-scenarios.ts` (`rbac-idor` の `mode: "live"`) + `src/components/auth/PermissionModel.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |
 | DESIGN/30 §5.3 (Phase 2 PoC 第 4 号) | `src/components/auth/attacks/scenarios/session-token-scenarios.ts` (`session-fixation` の `mode: "live"`) + `src/components/auth/AuthComparison.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 |
+| DESIGN/32 §4.7 (TOTP 脆弱エンドポイント) | `services/victim-web/src/routes/totp-vuln.ts` + `services/victim-web/src/utils/totp.ts` | `POST /totp/login-replay` (used_otps 記録なしで同一 OTP 2 連続認証 + leakedToAttacker 漏えい体験) |
+| DESIGN/32 §8.1 (victim 単体テスト) | `services/victim-web/__tests__/totp-vuln.test.ts` | TOTP: 同一 OTP 2 連続認証 / secret 学習者上書き / 不在 user 401 / username 欠如 400 / invalid JSON 400 |
+| DESIGN/30 §5.3 (シナリオ e2e — mfa-otp-replay) | `server/__tests__/scenarios/mfa-otp-replay.test.ts` | mfa-otp-replay: orchestrator → victim-web で 200 / X-Computed-OTP ヘッダ / leakedToAttacker / 3 段 AttackStep / ghost user → blocked |
+| DESIGN/30 §5.3 (Phase 2 PoC 第 5 号 = Phase 2 完結) | `src/components/auth/attacks/scenarios/mfa-scenarios.ts` (`mfa-otp-replay` の `mode: "live"` + 7 シーン story) + `src/components/auth/MfaFlow.tsx` (`onRunLiveScenario` 配線) | 学習者検証経路 + 紙芝居化 |
+| DESIGN/35 §2 (AttackStoryScene 型) | `shared/api-types.ts` (`AttackStoryScene`, `AttackStoryActor`, `AttackStoryVisual`, `RawExchangeRef`, `HttpHighlight`) + `AttackScenarioMeta.story?` 追加 | 紙芝居データモデル |
+| DESIGN/35 §3 (UI コンポーネント分割) | `src/components/shared/AttackStoryView.{tsx,css}` + `AttackStoryScene.{tsx,css}` + `AttackStoryControls.{tsx,css}` + `StoryActorAvatar.tsx` | 統合コンテナ + シーン描画 + ナビ + キャラアバター |
+| DESIGN/35 §4 (AttackPanel 統合) | `src/components/shared/AttackPanel.tsx` (`hasStory()` メモ + AttackStoryView 表示 + `<details>` 折りたたみの classic timeline) + `AttackPanel.css` (`.attack-classic-timeline-fold`) | 共存方式 (story 持ちは新 UI、未対応は従来 timeline 展開) |
+| DESIGN/35 §7 (raw exchange リンク方式) | `src/utils/story-resolver.ts` (`resolveRawRef` case-insensitive header lookup) + `src/utils/__tests__/story-resolver.test.ts` | 構造体参照ヘルパー |
+| DESIGN/35 §11.2-§11.6 (テスト要件) | `src/components/shared/__tests__/AttackStoryView.test.tsx` (11 cases) + `AttackStoryScene.test.tsx` (8 cases) + `src/utils/__tests__/story-resolver.test.ts` (7 cases) | UI navigation / variant 描画 / a11y / resolver helper |
 
 ## ロードマップ: 攻撃デモの live 化 (Phase 1-5, 約 11 週)
 

--- a/DESIGN/33-raw-http-composer.md
+++ b/DESIGN/33-raw-http-composer.md
@@ -35,6 +35,7 @@ safety-reviewed: false
 - `DataFlowPanel`: 4 番目のタブ "Sequence" を追加し `SequenceDiagramView` を内包
 - ~~`AttackStepTimeline`: `mode: "live"` では orchestrator レスポンスの `rawExchange` から steps を生成~~ → **PR-1 で obsolete**: orchestrator が live 経路でも probe/exploit|blocked/verify の 3 ステップを生成し `result.steps[]` に詰めて返すため、フロント派生は冗長。raw bytes の視覚化は `SequenceDiagramView` が担当する。詳細は §4.1 参照。
 - `AttackResultBanner` / `AttackDefensePanel`: 変更なし (両モード共通)
+- `AttackStoryView` (DESIGN/35): **共存** — `AttackPanel` 内で `RawHttpComposer` の下に `AttackStoryView` を表示し、既存の `AttackStepTimeline` は `<details>` で折りたたむ (story 持ちシナリオのみ)。story 未定義シナリオでは従来通り `AttackStepTimeline` を展開表示する。`SequenceDiagramView` (機械的事実) と `AttackStoryView` (物語的解釈) は補完関係 (DESIGN/35 §14.1)。Phase 2 PR-4 で初導入
 
 ---
 

--- a/DESIGN/35-attack-storyboard.md
+++ b/DESIGN/35-attack-storyboard.md
@@ -1,0 +1,782 @@
+---
+title: 攻撃デモカタログ — AttackStoryboard (紙芝居型攻撃可視化) UI 仕様
+phase: design
+audience: フロントエンド開発者・教材執筆者・UI レビュアー
+last-updated: 2026-05-10
+safety-reviewed: false
+---
+
+# 35. AttackStoryboard (紙芝居型攻撃可視化) UI 仕様
+
+## 1. 目的とスコープ
+
+### 1.1 解決する課題
+
+PR #6 (becc5fc) でリリース、PR #14/#17/#18/#19 で順次 live 化された攻撃デモカタログ (38 シナリオ) は、
+`AttackPanel` が「実行ボタン → 結果一括ドン」型 UI のため、攻撃の **時系列の物語** が立ち上がらない。
+具体的な不足点は以下の通り。
+
+| 課題 | 現状の挙動 | 学習者への影響 |
+|---|---|---|
+| 攻撃者・被害者・サーバの視点が混ざる | `AttackStepTimeline` が probe/exploit/verify の機械的 3 段カードのみ | 「誰が」「いつ」攻撃を仕掛けたかの人物視点が欠ける |
+| 漏えいデータが平文 JSON として埋もれる | `AttackResultBanner` の summary に短文表示 | 「攻撃で何が奪取されたか」が一目で分からない |
+| 攻撃成立の瞬間が点で表現される | 1 リクエスト = 1 結果で時系列がない | 「いつ・どう成立したか」のドラマが体感できない |
+
+ユーザー評価: 「攻撃側がどういう攻撃で何をとれてしまうのかがわかりずらい」(2026-05-10)
+
+### 1.2 解決方針
+
+攻撃シナリオ (`AttackScenarioMeta`) に `story?: AttackStoryScene[]` を持たせ、
+共通コンポーネント `AttackStoryView` が紙芝居 (キャラ + 吹き出し + ◄ ► + auto-play) として再生する。
+
+| 提供する体験 | 説明 |
+|---|---|
+| シーン進行 | 5–7 シーンを ◄ ► で手動進行、または auto-play で自動再生 |
+| キャラクター | 😈 attacker / 👤 victim / 🖥️ server 等のアバターと吹き出し |
+| ビジュアル variants | http-request/http-response/data-leak/code-defense/sequence-arrow/ascii |
+| raw exchange リンク | live モードで `RawExchange` 内のフィールドをハイライト参照 |
+| 既存 UI との共存 | `AttackStepTimeline` は折りたたみで残置、フォールバック互換 |
+
+### 1.3 スコープ外
+
+- 大量の SVG/Canvas 凝ったアニメーション (PCB テーマと干渉)
+- raw HTTP の編集 UI (それは `RawHttpComposer` の責務、DESIGN/33)
+- `SequenceDiagramView` の置換 (機械的事実は SequenceDiagram、物語的解釈は本仕様で棲み分け)
+- 音声効果・BGM (silent 原則を維持)
+
+### 1.4 既存 DESIGN との関係
+
+- 本仕様は `DESIGN/30` の Phase 戦略に乗り、Phase 2 PR-4 (mfa-otp-replay) で初導入し Phase 3 で他 13 件に波及
+- `DESIGN/33` (RawHttpComposer / SequenceDiagramView) と棲み分け (詳細 §14)
+- `DESIGN/04` (safety guardrails) の「明示」「防御策併記」原則を継承 (story 末尾に防御発動シーン必須化)
+- `DESIGN/02` (UI spec) のコンポーネント仕様スタイルを継承
+
+---
+
+## 2. データモデル (`AttackStoryScene` 型)
+
+### 2.1 中核型 (推奨案)
+
+```typescript
+// shared/api-types.ts に追加
+
+/** 攻撃シナリオの 1 シーン (紙芝居の 1 ページ) */
+export interface AttackStoryScene {
+  /** 安定 ID (story 配列内ユニーク)。テスト・キーボード遷移・ディープリンクで使用 */
+  id: string;
+  /** シーンタイトル (例: "アリスの OTP を肩越しに観測") */
+  title: string;
+  titleJa: string;
+  /** 吹き出し speech と背景説明 narration の主軸を持つアクター */
+  actor: AttackStoryActor;
+  /** 吹き出しテキスト。キャラ視点の一人称 (常体)。null=吹き出しなし (純ナレーション) */
+  speech?: { ja: string; en: string } | null;
+  /** 第三者ナレーション (敬体)。シーン下部に表示 */
+  narration?: { ja: string; en: string } | null;
+  /** 中央の図解。type 別のタグ付きユニオン (§2.2) */
+  visual?: AttackStoryVisual;
+  /** 同時にハイライトする他アクター (例: attacker speech 中、victim/server を薄表示) */
+  highlightActors?: AttackStoryActor[];
+  /** auto-play 時のシーン表示時間 (ms)。未指定は story 全体のデフォルト (3000ms) */
+  durationMs?: number;
+}
+
+export type AttackStoryActor =
+  | "attacker"   // 攻撃者 (😈 / 橙)
+  | "victim"     // 被害者ユーザ (👤 / 青)
+  | "server"     // 認証サーバ / orchestrator (🖥️ / 緑)
+  | "victim-srv" // victim コンテナ自体 (live モード) (🔓 / 橙赤)
+  | "narrator"   // 第三者解説 (📢 / グレー)
+  | "system";    // ブラウザ・ネットワーク・generic (🌐 / シアン)
+```
+
+### 2.2 ビジュアル variants (タグ付きユニオン)
+
+```typescript
+export type AttackStoryVisual =
+  /** raw HTTP リクエスト/レスポンス。highlight でフィールド強調 */
+  | { type: "http-request"; sourceRef: RawExchangeRef; highlight?: HttpHighlight[] }
+  | { type: "http-response"; sourceRef: RawExchangeRef; highlight?: HttpHighlight[] }
+  /** 漏えい/取得データの強調表示 (赤囲い + ラベル) */
+  | {
+      type: "data-leak";
+      label: string;
+      labelJa: string;
+      valueRef: RawExchangeRef;
+      severity?: "info" | "high" | "critical";
+    }
+  /** 防御コードのハイライト (codeHints から抜粋) */
+  | { type: "code-defense"; codeHintIndex: number; lineHighlight?: [number, number] }
+  /** シーケンス矢印の単発表示 (SequenceDiagramView を再利用しない簡易版) */
+  | {
+      type: "sequence-arrow";
+      from: AttackStoryActor;
+      to: AttackStoryActor;
+      label: string;
+      labelJa: string;
+      direction: "request" | "response";
+    }
+  /** 自由テキスト/ASCII 図 (簡易フォールバック) */
+  | { type: "ascii"; content: string };
+```
+
+### 2.3 raw exchange への参照 (`RawExchangeRef`)
+
+```typescript
+/** raw exchange 内の特定フィールドへの参照 (§7 で詳細議論) */
+export interface RawExchangeRef {
+  /** どのペアか */
+  pair: "browserToOrchestrator" | "orchestratorToVictim";
+  /** request か response か */
+  side: "request" | "response";
+  /** どこを参照するか (case-insensitive header name 含む) */
+  field: "line" | "body" | { header: string };
+}
+
+export interface HttpHighlight {
+  /** 強調する部位 */
+  target: "header" | "body-fragment" | "status";
+  /** ヘッダ名 or 検索文字列 */
+  match: string;
+  /** ホバー説明 (省略可) */
+  tooltipJa?: string;
+  tooltip?: string;
+}
+```
+
+### 2.4 既存 `AttackScenarioMeta` への追加フィールド
+
+```typescript
+// shared/api-types.ts の AttackScenarioMeta 末尾に追加
+export interface AttackScenarioMeta {
+  /* ... 既存フィールド (id, tabId, name, ..., codeHints, modes, mode, liveTemplate) ... */
+
+  /** 紙芝居型物語シーン。未指定/空配列のシナリオは AttackStoryView を非表示 */
+  story?: AttackStoryScene[];
+
+  /** auto-play デフォルト ms (省略時 3000)。シナリオ単位で上書き可能 */
+  storyDefaultDurationMs?: number;
+}
+```
+
+### 2.5 設計判断 (代替案との比較)
+
+| 案 | 内容 | メリット | デメリット | 採否 |
+|---|---|---|---|---|
+| A | discriminated union (上記) | 型安全、IDE 補完が効く | variant 追加で型膨張 | **採用** |
+| B | 自由形式 `Record<string, unknown>` | 柔軟 | 型安全性ゼロ、テスト不能 | 不採用 |
+| C | visual を別ファイル化 (`AttackStoryVisualSpec`) | 関心の分離 | scenario 1 ファイルで完結しない | Phase 3 で再評価 |
+
+---
+
+## 3. UI コンポーネント分割
+
+### 3.1 ファイル構成 (推奨案)
+
+```
+src/components/shared/
+├── AttackStoryView.tsx       統合コンテナ (シーン状態管理・auto-play・◄ ► 配線)
+├── AttackStoryView.css
+├── AttackStoryScene.tsx      1 シーンの描画 (キャラ + 吹き出し + ビジュアル)
+├── AttackStoryScene.css
+├── AttackStoryControls.tsx   ◄ ► / dot indicator / auto-play toggle
+├── AttackStoryControls.css
+└── StoryActorAvatar.tsx      内部用 (emoji ベースのアクターアバター)
+```
+
+### 3.2 案比較
+
+| 案 | ファイル数 | 評価 |
+|---|---|---|
+| A | 1 ファイル (`AttackStoryView.tsx` のみ) | △ シーン描画ロジックが肥大化、テスト困難 |
+| B | **4 ファイル分割 (上記)** | **採用**: 各責務明確、個別テスト可能 |
+| C | visual variant ごとに別ファイル | × 過剰 (`<Switch><Match>` で十分) |
+
+### 3.3 各ファイルの責務
+
+#### `AttackStoryView.tsx`
+
+```typescript
+interface AttackStoryViewProps {
+  story: AttackStoryScene[];
+  /** live モードでの raw exchange。null/undefined でも動作 (visual がフォールバック) */
+  rawExchange?: import("../../../shared/api-types").RawExchange | null;
+  /** auto-play デフォルト ms (props 未指定時は 3000) */
+  defaultDurationMs?: number;
+}
+```
+
+- 内部 signal: `currentIndex: number`, `autoPlay: boolean`, `paused: boolean`
+- `createEffect` で auto-play タイマ管理 + `prefers-reduced-motion` 判定
+- キーボードイベント (← → Space Esc Home End) を root 要素にバインド
+- `<AttackStoryScene>` と `<AttackStoryControls>` を構成
+
+#### `AttackStoryScene.tsx`
+
+```typescript
+interface AttackStorySceneProps {
+  scene: AttackStoryScene;
+  rawExchange?: RawExchange | null;
+}
+```
+
+- `<Switch><Match>` で `visual.type` を分岐描画
+- `solid-motionone` の `<Motion.div>` でフェードイン (200ms)
+- アクターアバターを左/中/右に配置 (CSS Grid)
+- 吹き出しは `clip-path` の三角 + border 枠
+
+#### `AttackStoryControls.tsx`
+
+```typescript
+interface AttackStoryControlsProps {
+  current: number;
+  total: number;
+  autoPlay: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+  onJump: (index: number) => void;
+  onToggleAutoPlay: () => void;
+}
+```
+
+- `StepControl.tsx` の DNA を継承しつつ dot indicator + auto-play toggle を追加
+- (note) 既存 `StepControl.tsx` には dot 機能がないため流用ではなく類型コンポーネントとする。DRY 化は Phase 3 で再評価
+
+#### `StoryActorAvatar.tsx` (内部用)
+
+```typescript
+interface StoryActorAvatarProps {
+  actor: AttackStoryActor;
+  active?: boolean;
+}
+```
+
+- emoji ベースの描画。Phase 1 では emoji 直接、将来 SVG コンポーネントに置換可能 (シナリオデータは無変更)
+
+### 3.4 SolidJS 1.9 規約遵守 (必須)
+
+- props は常に `props.xxx` (デストラクチャ禁止)
+- 早期 return 禁止 → `<Show fallback={...}>`
+- 配列更新は `setX(prev => ...)` パターン
+- `for` ループは `<For each={}>`
+
+---
+
+## 4. AttackPanel との統合
+
+### 4.1 統合方針 (3 案比較)
+
+| 案 | 内容 | 採否 |
+|---|---|---|
+| A | **置換**: AttackStoryView が AttackStepTimeline + AttackResultBanner を完全置換 | △ 全シナリオ story 完成まで実施不可、退行リスク高 |
+| B | **共存**: story を持つシナリオは story 表示、既存 timeline は折りたたみで残置 | **採用** (Phase 1-3 の全期間で安全) |
+| C | **タブ追加**: DataFlowPanel に "Story" タブを追加 | × story は攻撃の主役 UI、tab 内では弱い |
+
+### 4.2 統合レイアウト (案 B)
+
+```
+AttackPanel
+├── 1. EducationalWarningBanner
+├── 2. AttackScenarioSelector
+├── 3. mode labels (両モード並列表示ラベル)
+├── 4a. <Show when={isLiveMode()}> RawHttpComposer </Show>
+├── 4b. <Show when={!isLiveMode()}> AttackRunButton </Show>
+│
+├── ★NEW★ 5. <Show when={hasStory() && hasRunResult()}>
+│              AttackStoryView (story={selectedScenario().story} rawExchange={rawExchange()})
+│            </Show>
+│
+├── 6. <details class="attack-classic-timeline-fold">  ← 既存 timeline を折りたたみ
+│        <summary>{t("詳細ステップを見る", "Show detailed steps")}</summary>
+│        AttackStepTimeline
+│      </details>
+│
+├── 7. AttackDefensePanel
+├── 8. AttackResultBanner       ← story 終了後の機械的事実として最下段に残す (§15 O1)
+└── 9. DataFlowPanel
+```
+
+### 4.3 fallback 挙動 (story 未定義シナリオ)
+
+- `story` が `undefined` または `[]` のとき AttackStoryView 自体を非表示 (`<Show when={hasStory()}>`)
+- AttackStepTimeline を `<details open>` (展開状態) で表示し、現状 UX を維持
+- Phase 3 で全シナリオに story が揃ったら `<details>` を default closed に切替 (DESIGN/35 改訂で対応)
+
+### 4.4 attackResult との連動
+
+- `attackResult` が `null` (未実行) の間は AttackStoryView を非表示 (空状態を見せない)
+- `attackResult` が更新されたタイミングで `AttackStoryView` の `currentIndex` を 0 にリセット
+- `outcome === "succeeded"` のシナリオは story 末尾に「攻撃成立」シーンを挟む規約 (§8.3)
+- `outcome === "blocked"` のシナリオは末尾に「防御発動」シーンを挟む規約 (§8.3)
+- `outcome === "error"` のシナリオは story 非表示 + AttackStepTimeline 表示にフォールバック (§15 O2)
+
+---
+
+## 5. インタラクション仕様
+
+### 5.1 ナビゲーション
+
+| 操作 | 動作 |
+|---|---|
+| ► (進む) | `currentIndex + 1`、最終シーンで disabled |
+| ◄ (戻る) | `currentIndex - 1`、最初のシーンで disabled |
+| dot クリック | `currentIndex = i` にジャンプ |
+| キーボード `→` / `Space` | 進む (auto-play 中は pause) |
+| キーボード `←` | 戻る |
+| キーボード `Esc` | auto-play 停止 |
+| キーボード `Home` / `End` | 最初/最後のシーンへ |
+
+### 5.2 auto-play 挙動
+
+- toggle ボタン (▶ Auto-play / ⏸ Pause)
+- ON 時、`scene.durationMs ?? story.defaultDurationMs ?? 3000` ごとに `currentIndex + 1`
+- 最終シーン到達で auto-play 自動停止
+- `prefers-reduced-motion: reduce` 検出時は **default OFF** (`createEffect` で初期化)
+- ユーザが手動操作 (◄ ► / dot ジャンプ) したら auto-play 一時停止
+
+### 5.3 a11y 要件
+
+- root 要素に `role="region"` + `aria-label="攻撃ストーリーボード / Attack storyboard"`
+- 現在シーン番号の dot に `aria-current="step"`
+- シーン切替時に `aria-live="polite"` ステータス領域へ「シーン X / Y: タイトル」をアナウンス
+- 各 dot ボタンに `aria-label="シーン X へジャンプ / Jump to scene X"`
+- auto-play ボタンに `aria-pressed={autoPlay()}`
+- キーボード focus は ◄ ► のいずれかにデフォルト配置、tab で controls → scene の順
+
+---
+
+## 6. アニメーション
+
+### 6.1 シーン間遷移 (案比較)
+
+| 案 | 実装 | 採否 |
+|---|---|---|
+| A | cut (なし) | △ 紙芝居らしさ薄い |
+| B | **fade** | **採用**: solid-motionone で `opacity 0→1` 200ms、シンプル、reduced-motion 対応容易 |
+| C | slide | △ 演出強いがレイアウトずれリスク |
+| D | variant ごとに変える (`scene.transition` 導入) | × 過剰、authoring 負担増 |
+
+### 6.2 アクターハイライト切替
+
+- CSS class 切替で `box-shadow` / `border-color` を変える (`transition: 200ms ease`)
+- highlight 中のアクターに `data-active="true"` 属性 (CSS セレクタ用)
+- 非 highlight アクターは `opacity: 0.4`、色相変化は使わない (色弱配慮)
+
+### 6.3 reduced-motion 対応
+
+```typescript
+const prefersReduced = () =>
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+// Motion 適用時に prefersReduced() ? 0 : 200 で transition 無効化
+```
+
+- AttackStoryView 全体で reduce 検出時は `transition: none` のクラスを root に付与
+- auto-play は **default OFF**、ただしユーザが ON にすれば動作 (尊重するが選択を奪わない)
+
+---
+
+## 7. raw exchange リンク方式
+
+### 7.1 案比較
+
+| 案 | 例 | メリット | デメリット | 採否 |
+|---|---|---|---|---|
+| A | **構造体参照** (`RawExchangeRef`) | `{ pair: "orchestratorToVictim", side: "request", field: { header: "Cookie" } }` | 型安全、補完、テスト容易、シリアライズ可 | やや冗長 | **採用** |
+| B | JSON pointer (`"/orchestratorToVictim/request/headers/Cookie"`) | 標準仕様 (RFC 6901) | string 検証必要、補完なし、case-sensitive | 不採用 |
+| C | resolver 関数 (`(ex) => ex.orchestratorToVictim.request.headers["Cookie"]`) | 最も柔軟 | シリアライズ不能、テスト DB に保存不可 | 不採用 |
+
+### 7.2 ヘルパー実装
+
+```typescript
+// src/utils/story-resolver.ts (新規)
+import type { RawExchange } from "../../shared/api-types";
+import type { RawExchangeRef } from "../../shared/api-types";
+
+/**
+ * RawExchangeRef を実値に解決する。
+ * - header 検索は case-insensitive (HTTP 仕様準拠)
+ * - 解決失敗 (パスが無い等) は undefined を返し、UI でプレースホルダ "—" を表示
+ */
+export function resolveRawRef(
+  ref: RawExchangeRef,
+  exchange: RawExchange | null | undefined,
+): string | undefined {
+  if (!exchange) return undefined;
+  const pair = exchange[ref.pair];
+  if (!pair) return undefined;
+  const sideObj = pair[ref.side] as
+    | { line: string; headers: Record<string, string>; body: string | null }
+    | undefined;
+  if (!sideObj) return undefined;
+  if (ref.field === "line") return sideObj.line;
+  if (ref.field === "body") return sideObj.body ?? undefined;
+  if (typeof ref.field === "object" && "header" in ref.field) {
+    const target = ref.field.header.toLowerCase();
+    for (const [k, v] of Object.entries(sideObj.headers)) {
+      if (k.toLowerCase() === target) return v;
+    }
+  }
+  return undefined;
+}
+```
+
+### 7.3 表現例
+
+```typescript
+// シーン例: 「攻撃者は被害者の OTP を盗む」
+{
+  id: "scene-3-otp-leak",
+  title: "OTP intercepted",
+  titleJa: "OTP が漏えい",
+  actor: "attacker",
+  speech: { ja: "OTPを観測した。123456だ。", en: "Got the OTP: 123456." },
+  visual: {
+    type: "data-leak",
+    label: "TOTP code",
+    labelJa: "TOTP コード",
+    valueRef: { pair: "orchestratorToVictim", side: "response", field: { header: "X-Computed-OTP" } },
+    severity: "high",
+  },
+}
+```
+
+### 7.4 raw exchange 不在時の挙動
+
+- narration 型 (`mode !== "live"`) では `rawExchange` は常に `null`
+- `valueRef` 解決失敗時は visual を fallback 表示 (label のみ + プレースホルダ "—")
+- 警告ログは出さない (シナリオ作者の意図的選択もありうる)
+
+---
+
+## 8. シナリオ作成ガイドライン
+
+### 8.1 推奨シーン数
+
+**5–7 シーン**
+
+- 4 以下: すぐ終わる紙芝居感、物語性が薄い
+- 8 以上: 学習者の集中切れ、auto-play で 24 秒超
+- 上限: 10 (`durationMs` 短縮で吸収可能)
+
+### 8.2 標準テンプレ (5 シーン版)
+
+```
+Scene 1: setup       誰が・何を狙うか (attacker speech + 自身のアバター)
+Scene 2: probe       攻撃者がサーバを観察・偵察 (sequence-arrow visual)
+Scene 3: exploit     攻撃の核 (http-request visual + 強調 highlight)
+Scene 4: leak        漏えい・成立の瞬間 (data-leak visual)
+Scene 5: outcome     成立 or 防御発動 (code-defense visual or banner)
+```
+
+### 8.3 標準テンプレ (7 シーン版 — mfa-otp-replay 等の複雑系)
+
+```
+Scene 1: setup       (attacker)  目的設定
+Scene 2: observation (attacker)  OTP 観測 (肩越し / フィッシング中継 / 録画)
+Scene 3: victim-act  (victim)    被害者が正規ログインを試みる
+Scene 4: replay      (attacker)  攻撃者が同じ OTP をリプレイ
+Scene 5: server      (server)    サーバが OTP を再受理してしまう (used 記録なし)
+Scene 6: leak        (attacker)  攻撃者がアカウント乗っ取り成立 (data-leak)
+Scene 7: defense     (narrator)  used_otps 記録があれば防げた (code-defense)
+```
+
+### 8.4 文量・トーン規約
+
+| 要素 | 推奨 | 上限 |
+|---|---|---|
+| `title` / `titleJa` | 短い名詞句 (3–6 語) | 全角 20 字 |
+| `speech` (キャラ吹き出し) | 1–2 文の常体・口語 (例: 「OTPを盗んだ」) | 全角 60 字 |
+| `narration` (第三者) | 1–2 文の敬体・解説 (例: 「サーバは...しません」) | 全角 100 字 |
+| `visual.label` | 短い名詞 | 全角 20 字 |
+
+### 8.5 ja/en 必須ルール
+
+- すべての表示テキストは `{ ja, en }` 両建て (`useI18n().t()` 経由で表示)
+- 例外: `id`, `actor` 等の機械フィールドは英語のみ
+- `code-defense` visual は `codeHints[].code` から参照のため、コード内コメントは ja のまま既存慣習を維持
+
+### 8.6 authoring チェックリスト (テストで自動検査)
+
+- [ ] `id` がストーリ内ユニーク
+- [ ] `actor` が `AttackStoryActor` enum 値
+- [ ] `speech` または `narration` のいずれかが必ず存在
+- [ ] `visual.type` が enum 値、対応する fields が揃う
+- [ ] `valueRef` の `pair` / `side` / `field` が型として有効
+- [ ] シーン総数 4–8 (推奨 5–7)
+- [ ] outcome シーン (最終) で attack 成立 or 防御発動が明示される
+
+---
+
+## 9. キャラクター表現
+
+### 9.1 emoji ベース (Phase 1 採用)
+
+| actor | emoji | CSS 変数 (色相) | 役割 |
+|---|---|---|---|
+| `attacker` | 😈 | `--color-attack-accent` (橙) | 悪意のある攻撃者 |
+| `victim` | 👤 | `--color-info` (青) | 被害者ユーザ |
+| `server` | 🖥️ | `--color-success` (緑) | 正規サーバ (orchestrator) |
+| `victim-srv` | 🔓 | `--color-attack-accent` (橙赤) | live モードの脆弱 victim コンテナ |
+| `narrator` | 📢 | `--text-muted` (グレー) | 第三者解説 |
+| `system` | 🌐 | `--glow-color` (シアン) | ブラウザ・ネットワーク |
+
+### 9.2 視覚デザイン
+
+- アバター: 直径 56px の角丸正方形 (PCB タイル風)、emoji を中央配置
+- 吹き出し: アバターの右側 (LTR) / 下側 (狭幅)、CSS `border` + `clip-path` 三角形
+- monospace フォント (`var(--font-mono)`) は attacker 吹き出しのみ、他は body フォント
+- アクティブアクターは `box-shadow: 0 0 12px var(--actor-color)` で発光 (PCB テーマ整合)
+
+### 9.3 抽象化レイヤ (将来 SVG 化への配慮)
+
+```typescript
+function StoryActorAvatar(props: { actor: AttackStoryActor; active?: boolean }) {
+  // Phase 1: emoji map で描画
+  // Phase 3+: actor → SVG component の switch に拡張可能
+  // シナリオデータ側は無変更で差し替え可能
+}
+```
+
+### 9.4 PCB テーマ統合
+
+- `--actor-attacker-color: var(--color-attack-accent)` 等のセマンティック CSS 変数を `app.css` に追加
+- アバター背景: `var(--bg-card)`、border: `var(--border-active)`
+- 攻撃成立シーンでは attacker アバターに `glow-strong` クラス併用 (既存 glow effect 流用)
+
+### 9.5 emoji 使用の例外規約 (重要)
+
+CLAUDE.md / DESIGN/04 では `AttackStep` の icon (▶◉✎ 等) について絵文字禁止としているが、
+本仕様の **キャラ表現は明示的に例外** とする。
+
+| 用途 | 絵文字 | 理由 |
+|---|---|---|
+| `AttackStep` の status icon | ✗ 禁止 | 機械的・記号的表現が望ましい (CLAUDE.md / DESIGN/04) |
+| `StoryActorAvatar` の人物表現 | ✓ **本仕様で許可** | 人物視点の物語性を出すため不可欠 |
+
+`StoryActorAvatar` 以外のコンポーネントへの emoji 使用波及は禁止する。
+
+---
+
+## 10. Phase 戦略 (波及計画)
+
+### 10.1 Phase 1 (本 PR / mfa-otp-replay)
+
+- 共通基盤 (AttackStoryView / AttackStoryScene / AttackStoryControls / StoryActorAvatar / types) 実装
+- `mfa-otp-replay` シナリオに 7 シーン story 執筆 (§8.3 テンプレ)
+- AttackPanel への統合 (案 B 共存方式)
+- 既存 4 件 (jwt-alg-none, oauth-state-csrf, rbac-idor, session-fixation) の story は **未着手**
+  → これらは story 未定義のためフォールバック挙動 (timeline のみ表示) で動作
+
+### 10.2 Phase 2 (波及 PR、別 PR)
+
+| 案 | 内容 | 採否 |
+|---|---|---|
+| A | 既存 4 件を 1 つの PR で一括 story 化 | △ レビュー集中、UX 一貫性確保だが大 PR |
+| B | 1 シナリオ = 1 PR で 4 PR 化 | △ 段階的、レビュー軽量だが調整コスト |
+| C | **2 件ずつ 2 PR** (auth 系: jwt + oauth / app 系: rbac + session) | **採用**: バランス + ドメイン同質性 |
+
+### 10.3 Phase 3 (A 群残り 13 件)
+
+- 1 PR / シナリオを基本 (PR 細分化、レビュー軽量化)
+- 共通テンプレ (§8.2 / §8.3) を `DESIGN/35-templates/` に置いて authoring 高速化
+- Phase 3 完了時点で AttackStepTimeline を default closed に切替 (DESIGN/35 改訂)
+- A 群完了基準: 全 17 件のシナリオに `story.length >= 4`
+
+### 10.4 narration 型シナリオへの波及
+
+- C/D 群 (15 件) もポテンシャル対象
+- ただし narration 型は `rawExchange` を持たないため visual の `http-request` / `data-leak` で valueRef が常に解決失敗
+- → narration 用 visual variant `narration-only` (text + ASCII のみ) を将来追加検討 (§15 O11)
+
+---
+
+## 11. テスト要件
+
+### 11.1 構造テスト (`*-scenarios.test.ts`)
+
+全シナリオ走査:
+
+- story が存在する場合 §8.6 の authoring チェックリストを自動検証
+- `valueRef.field.header` が有効な header name か (case-insensitive 重複チェック)
+- `codeHintIndex` が `codeHints[]` のインデックスとして有効
+- vitest の `describe.each(scenarios)` パターン
+
+### 11.2 UI 単体テスト (`AttackStoryView.test.tsx`)
+
+- ◄ ► ボタンの enabled/disabled (端での)
+- dot クリックで `currentIndex` が変わる
+- キーボード ← → Space Esc Home End の動作
+- auto-play toggle で `setInterval` が走る (`vi.useFakeTimers`)
+- `prefers-reduced-motion: reduce` 環境で auto-play default OFF
+- aria-live のシーン切替アナウンス
+
+### 11.3 visual variant 描画テスト (`AttackStoryScene.test.tsx`)
+
+- `<AttackStoryScene>` を各 variant で render し、想定 DOM が出る
+- `data-leak` variant: severity 別 CSS class 付与
+- `code-defense` variant: 範囲ハイライト DOM 範囲
+
+### 11.4 a11y 検証
+
+- `role="region"` 存在
+- `aria-current="step"` が現在シーンの dot のみに付く
+- focus trap なし (region 外への tab 移動可能)
+- 既存テスト基盤 (`@solidjs/testing-library` + `@testing-library/jest-dom`) 流用
+
+### 11.5 snapshot テストは使わない方針
+
+- visual variant は構造的、文字列は i18n 依存で変動
+- assertion-based テストのほうが意図が明確
+
+### 11.6 resolver ヘルパー単体テスト (`story-resolver.test.ts`)
+
+- header lookup の case-insensitive 検証
+- 不在パス → undefined
+- 不正な field → undefined
+- `body: null` の正しい扱い
+
+---
+
+## 12. i18n / a11y
+
+### 12.1 i18n
+
+- 既存 `useI18n().t(ja, en)` を継承
+- scene 内 `speech.ja` / `speech.en` を直接読む (`t(scene.speech.ja, scene.speech.en)`)
+- 共通文言 (◄/► ラベル, "Auto-play" 等) は AttackStoryControls 内で `t()` 呼び出し
+- 想定文言一覧 (抜粋):
+
+| 概念 | ja | en |
+|---|---|---|
+| 進む | 次のシーン | Next scene |
+| 戻る | 前のシーン | Previous scene |
+| dot ラベル | シーン {n} へ | Jump to scene {n} |
+| auto-play ON | 自動再生中 | Auto-playing |
+| auto-play OFF | 自動再生開始 | Start auto-play |
+| シーン位置 | シーン {current} / {total} | Scene {current} of {total} |
+
+### 12.2 a11y 必須事項 (再掲 + 追加)
+
+- `prefers-reduced-motion` 尊重 (§6.3)
+- キーボード操作完備 (§5.3)
+- 全 emoji に `aria-hidden="true"` + 隣接ラベル (`aria-label`) でスクリーンリーダ向け代替テキスト
+- 吹き出しの色相だけに依存しない (アバター内に actor 名テキストも含める)
+
+---
+
+## 13. ファイル配置
+
+### 13.1 推奨配置 (新規ディレクトリは作らない)
+
+```
+src/components/shared/
+├── AttackStoryView.tsx          ★新規
+├── AttackStoryView.css          ★新規
+├── AttackStoryScene.tsx         ★新規
+├── AttackStoryScene.css         ★新規
+├── AttackStoryControls.tsx      ★新規
+├── AttackStoryControls.css      ★新規
+├── StoryActorAvatar.tsx         ★新規 (内部用)
+└── __tests__/
+    ├── AttackStoryView.test.tsx ★新規
+    └── AttackStoryScene.test.tsx ★新規
+
+src/utils/
+├── story-resolver.ts            ★新規
+└── __tests__/
+    └── story-resolver.test.ts   ★新規
+
+shared/
+└── api-types.ts                 既存に AttackStoryScene 等を追加
+
+src/components/auth/attacks/scenarios/
+└── mfa-scenarios.ts             既存の mfa-otp-replay に story 追加
+
+src/components/shared/
+└── AttackPanel.tsx              既存。§4.2 の統合レイアウトを反映
+```
+
+### 13.2 案比較
+
+| 案 | 配置 | 採否 |
+|---|---|---|
+| A | **`src/components/shared/` にフラット展開 (上記)** | **採用**: 既存 AttackPanel 兄弟と並ぶ自然な配置 |
+| B | `src/components/shared/storyboard/` 新規ディレクトリ | △ 既存パターン (フラット展開) と不一致 |
+| C | `src/components/auth/attacks/storyboard/` (auth 配下) | × 共有コンポーネントとして他 view で再利用不能 |
+
+---
+
+## 14. 既存 DESIGN/33 (RawHttpComposer / SequenceDiagram) との関係
+
+### 14.1 棲み分け
+
+| 観点 | DESIGN/33 | DESIGN/35 (本仕様) |
+|---|---|---|
+| 対象モード | live のみ | live + narration 両モード |
+| 焦点 | raw HTTP の編集と網目図 | 攻撃の物語進行 |
+| 主役 | byte / arrow | actor / scene |
+| 依存 | rawExchange 必須 | rawExchange optional |
+| ユーザ操作 | 編集 + 送信 | ◄ ► / auto-play / dot ジャンプ |
+
+両者は補完関係:
+
+- **SequenceDiagramView**: 「機械的な事実」(byte 単位の HTTP exchange)
+- **AttackStoryView**: 「物語的な解釈」(誰が・何を・どう奪取したか)
+
+`AttackStoryVisual.type === "sequence-arrow"` は SequenceDiagramView の簡易再表現 (依存しない、独自 SVG 1 本)。
+
+### 14.2 DESIGN/33 への変更必要性
+
+- AttackPanel の統合レイアウト (§4.2) は DESIGN/33 §4.2 と矛盾しない (story パネルが追加されるだけ)
+- DESIGN/33 §1.3 の「既存コンポーネントとの統合方針」表に「`AttackStoryView` 共存」の 1 行追加が必要 (本 PR スコープ)
+
+### 14.3 DESIGN/35 の独立性
+
+- 本仕様は DESIGN/33 を前提としない (narration シナリオでも動く)
+- DESIGN/02 (UI spec) のコンポーネント仕様スタイルを継承
+- DESIGN/04 (safety guardrails) の「明示」「防御策併記」原則を継承 (story 末尾に防御発動シーンを必須化する規約 §8.3)
+
+---
+
+## 15. オープン課題 (実装中に決めること)
+
+| # | 課題 | 影響 | 推奨アプローチ |
+|---|---|---|---|
+| O1 | `AttackResultBanner` を story 最終シーンに統合するか、別表示で残すか | UI 重複の可能性 | 残す (story 終了後に表示)。banner=機械的事実、story=物語表現で役割分担 |
+| O2 | story が `outcome === "error"` の attackResult のときどう挙動するか | error 時の物語が不在 | 専用 visual `type: "error"` を Phase 3 で追加。Phase 1 では story 非表示 + AttackStepTimeline 表示にフォールバック |
+| O3 | `data-leak` の `severity: critical` で audio cue を入れるか | a11y / 体験 | 入れない (silent 原則)。視覚的 pulse のみ |
+| O4 | dot indicator の最大数 (10 シーン超のシナリオ対応) | UI overflow | 8 dot で省略表示 (`... 5/12 ...`)。Phase 1 では §8.1 の 7 シーン推奨で運用 |
+| O5 | story データが大きくなった場合の lazy loading | bundle サイズ | Phase 3 で再評価。Phase 1 は同期 import で問題なし (1 シナリオ < 5KB) |
+| O6 | story 内で `attackResult.steps[]` を refer したいケース | データ重複 | `RawExchangeRef` を拡張し `{ source: "attackStep"; stepId: string; field: ... }` を Phase 3 で追加 |
+| O7 | i18n が ja/en 以外に拡張された場合 | 文言データ構造 | 既存 `t()` ヘルパーが lang 配列対応済み、本仕様は影響なし |
+| O8 | `narrator` actor のデザイン (擬人化しないキャラ) | キャラ表現の一貫性 | アバターを「📢」マイクアイコンに、`speech` ではなく必ず `narration` フィールドを使う規約 |
+| O9 | story preview (シナリオ選択前にホバーで一覧表示) | UX 拡張 | Phase 3 で検討。Phase 1 は実行後のみ表示 |
+| O10 | スマホ縦持ち時のレイアウト | レスポンシブ | アバター + 吹き出しを縦積み、controls をボトムバー化。CSS Grid で対応 |
+| O11 | narration 型シナリオ (C/D 群 15 件) への波及 visual variant | DESIGN/35 v2 範囲 | Phase 3 完了後に再評価。`narration-only` variant を追加して story を narration にも使えるようにするか検討 |
+
+---
+
+## 付録 A. 主要ファイル参照 (実装着手用)
+
+### 中核ファイル (絶対パス)
+
+- `shared/api-types.ts` — 型追加
+- `src/components/shared/AttackPanel.tsx` — 統合レイアウト変更
+- `src/components/shared/AttackStepTimeline.tsx` — 折りたたみ化
+- `src/components/auth/attacks/scenarios/mfa-scenarios.ts` — mfa-otp-replay に story 追加
+- `DESIGN/33-raw-http-composer.md` — §1.3 表に 1 行追加
+
+### 参照ファイル (パターン継承)
+
+- `src/components/shared/SequenceDiagramView.tsx` — raw exchange 参照パターン
+- `src/components/shared/StepControl.tsx` — controls の DNA
+- `src/i18n/context.tsx` — `t()` ヘルパー
+- `src/app.css` — CSS 変数 (`--color-attack-accent` 等)
+
+---
+
+## 改訂履歴
+
+| 日付 | 改訂内容 | 担当 |
+|---|---|---|
+| 2026-05-10 | 初版 (Plan agent ベースで起草、Phase 2 PR-4 = mfa-otp-replay live 化と同時着手) | Claude Opus 4.7 |

--- a/server/__tests__/scenarios/mfa-otp-replay.test.ts
+++ b/server/__tests__/scenarios/mfa-otp-replay.test.ts
@@ -1,0 +1,241 @@
+/**
+ * シナリオ固有 e2e テスト: mfa-otp-replay (Phase 2 PoC 第 5 号 = Phase 2 完結)
+ *
+ * orchestrator (server/routes/orchestrator-exec.ts) → 実 victim-web (services/victim-web)
+ * の経路で TOTP リプレイ脆弱性 (CWE-294) が成立することを検証する。
+ *
+ * orchestrator 基盤の挙動 (schema validation / VICTIM_ALLOWLIST / Host 強制 / production guard 等)
+ * は server/__tests__/orchestrator-live.test.ts でカバーされているため、本ファイルでは
+ * シナリオ固有の挙動 (脆弱パス / leakedToAttacker フィールド観察 / blocked 経路) のみを対象とする。
+ *
+ * DESIGN/30 §5.3 / DESIGN/32 §4.7 に対応。
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Hono } from "hono";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import { getRequestListener } from "@hono/node-server";
+import { traceMiddleware } from "../../middleware/trace-logger.js";
+import { productionGuard } from "../../middleware/production-guard.js";
+import { orchestratorExecRoutes } from "../../routes/orchestrator-exec.js";
+import { totpVulnRoutes } from "../../../services/victim-web/src/routes/totp-vuln.js";
+
+interface VictimInstance {
+  url: string;
+  close: () => Promise<void>;
+}
+
+/** 実 victim-web の totp-vuln ルートを in-process で起動。 */
+async function startVictimWeb(): Promise<VictimInstance> {
+  const app = new Hono();
+  app.route("/totp", totpVulnRoutes);
+  const handler = getRequestListener(app.fetch);
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+function createOrchestratorApp() {
+  const app = new Hono();
+  app.use("/api/*", traceMiddleware);
+  app.use("/api/orchestrator/*", productionGuard);
+  app.route("/api/orchestrator", orchestratorExecRoutes);
+  return app;
+}
+
+let victim: VictimInstance | null = null;
+
+beforeAll(async () => {
+  victim = await startVictimWeb();
+  process.env.VICTIM_WEB_BASE_URL = victim.url;
+  delete process.env.LIVE_ATTACK_PHASE;
+  delete process.env.NODE_ENV;
+});
+
+afterAll(async () => {
+  if (victim) {
+    await victim.close();
+    victim = null;
+  }
+  delete process.env.VICTIM_WEB_BASE_URL;
+});
+
+describe("Phase 2 PoC: mfa-otp-replay (orchestrator → victim-web)", () => {
+  it("既知 username で 200 + 同一 OTP の 2 連続認証 + leakedToAttacker が観察できる (脆弱性 e2e)", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "mfa-otp-replay",
+        target: "victim-web",
+        request: {
+          method: "POST",
+          path: "/totp/login-replay",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify({ username: "seed_alice" }),
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      success: boolean;
+      data: {
+        outcome: "succeeded" | "blocked" | "error";
+        rawExchange: {
+          orchestratorToVictim: {
+            request: { line: string };
+            response: { status: number; headers: Record<string, string>; body: string | null };
+            targetResolvedTo: string;
+          };
+        };
+        mode: string;
+      };
+    };
+
+    expect(json.success).toBe(true);
+    expect(json.data.outcome).toBe("succeeded");
+    expect(json.data.mode).toBe("live");
+
+    const ex = json.data.rawExchange.orchestratorToVictim;
+    expect(ex.request.line).toContain("POST /totp/login-replay");
+    expect(ex.response.status).toBe(200);
+    expect(ex.targetResolvedTo).toBe(victim!.url);
+
+    // 教材ヘッダ (storyboard が data-leak visual で参照する)
+    expect(ex.response.headers["x-computed-otp"]).toMatch(/^\d{6}$/);
+    expect(ex.response.headers["x-replay-detected"]).toBe("false");
+
+    // body の漏えい想定データを検証
+    const victimBody = JSON.parse(ex.response.body ?? "{}") as {
+      ok: boolean;
+      computedOtp: string;
+      victimLogin: { authenticatedAs: string; counterMatched: number };
+      attackerReplay: { authenticatedAs: string; counterMatched: number };
+      leakedToAttacker: {
+        userId: number;
+        username: string;
+        email: string;
+        demoBalance: string;
+        demoApiKey: string;
+      };
+      replayDetected: boolean;
+      usedOtpTracking: string;
+    };
+    expect(victimBody.ok).toBe(true);
+    expect(victimBody.computedOtp).toBe(ex.response.headers["x-computed-otp"]);
+    expect(victimBody.victimLogin.authenticatedAs).toBe("seed_alice");
+    expect(victimBody.attackerReplay.authenticatedAs).toBe("seed_alice");
+    expect(victimBody.victimLogin.counterMatched).toBe(victimBody.attackerReplay.counterMatched);
+    expect(victimBody.leakedToAttacker.userId).toBe(1);
+    expect(victimBody.leakedToAttacker.email).toBe("alice@victim.local");
+    expect(victimBody.leakedToAttacker.demoApiKey).toContain("REDACTED");
+    expect(victimBody.replayDetected).toBe(false);
+    expect(victimBody.usedOtpTracking).toBe("absent");
+  });
+
+  it("admin への昇格でも leakedToAttacker.demoBalance が $1,000,000.00 で漏えいする", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "mfa-otp-replay",
+        target: "victim-web",
+        request: {
+          method: "POST",
+          path: "/totp/login-replay",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ username: "seed_admin" }),
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: {
+        outcome: string;
+        rawExchange: { orchestratorToVictim: { response: { body: string | null } } };
+      };
+    };
+    expect(json.data.outcome).toBe("succeeded");
+    const victimBody = JSON.parse(
+      json.data.rawExchange.orchestratorToVictim.response.body ?? "{}",
+    ) as { leakedToAttacker: { userId: number; demoBalance: string } };
+    expect(victimBody.leakedToAttacker.userId).toBe(4);
+    expect(victimBody.leakedToAttacker.demoBalance).toBe("$1,000,000.00");
+  });
+
+  it("AttackStep が probe / exploit / verify の 3 段で生成される", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "mfa-otp-replay",
+        target: "victim-web",
+        request: {
+          method: "POST",
+          path: "/totp/login-replay",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ username: "seed_bob" }),
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: { steps: Array<{ id: string; kind: string; status: string }> };
+    };
+    const steps = json.data.steps;
+    expect(steps).toHaveLength(3);
+    expect(steps[0].kind).toBe("probe");
+    expect(steps[1].kind).toBe("exploit");
+    expect(steps[2].kind).toBe("verify");
+    expect(steps[1].status).toBe("success");
+    expect(steps[0].id).toBe("mfa-otp-replay-probe");
+    expect(steps[1].id).toBe("mfa-otp-replay-exploit");
+    expect(steps[2].id).toBe("mfa-otp-replay-verify");
+  });
+
+  it("不在 username では victim が 401 を返し、ステップは blocked になる", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "mfa-otp-replay",
+        target: "victim-web",
+        request: {
+          method: "POST",
+          path: "/totp/login-replay",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ username: "ghost_user" }),
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: {
+        outcome: string;
+        rawExchange: { orchestratorToVictim: { response: { status: number } } };
+        steps: Array<{ kind: string; status: string }>;
+      };
+    };
+    // victim が 401 を返したので、orchestrator は blocked 系のステップを出す
+    expect(json.data.rawExchange.orchestratorToVictim.response.status).toBe(401);
+    expect(json.data.outcome).toBe("succeeded"); // OrchestratorExecResponse 側は常に succeeded
+    const blockedStep = json.data.steps.find((s) => s.kind === "blocked");
+    expect(blockedStep).toBeDefined();
+    expect(blockedStep!.status).toBe("blocked");
+  });
+});

--- a/services/victim-web/__tests__/totp-vuln.test.ts
+++ b/services/victim-web/__tests__/totp-vuln.test.ts
@@ -1,0 +1,156 @@
+/**
+ * victim-web 単体テスト: POST /totp/login-replay (mfa-otp-replay 脆弱エンドポイント)
+ *
+ * orchestrator を介さずに victim-web 単体の脆弱性が成立することを直接確認する。
+ * orchestrator 経由の e2e は server/__tests__/scenarios/mfa-otp-replay.test.ts で別途検証する。
+ *
+ * DESIGN/32 §4.7 / §8.1 (Phase 2 PR-4 で追記): "POST /totp/login-replay — victim が
+ * 現在時刻 OTP を計算し、同じ OTP で 2 連続検証して両方 success を返すこと"
+ */
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { totpVulnRoutes } from "../src/routes/totp-vuln.js";
+import {
+  computeTotp,
+  currentCounter,
+} from "../src/utils/totp.js";
+
+function createApp() {
+  const app = new Hono();
+  app.route("/totp", totpVulnRoutes);
+  return app;
+}
+
+const DEMO_SECRET = "JBSWY3DPEHPK3PXP";
+
+describe("victim-web: POST /totp/login-replay (CWE-294 OTP replay)", () => {
+  it("既知 username + secret 省略で 200 + 同一 OTP の 2 連続認証が成立する (脆弱性の核心)", async () => {
+    const app = createApp();
+    const res = await app.request("/totp/login-replay", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "seed_alice" }),
+    });
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as {
+      ok: boolean;
+      computedOtp: string;
+      totpCounter: number;
+      victimLogin: { authenticatedAs: string; counterMatched: number; sessionId: string };
+      attackerReplay: { authenticatedAs: string; counterMatched: number; sessionId: string };
+      leakedToAttacker: {
+        userId: number;
+        username: string;
+        email: string;
+        demoBalance: string;
+        demoApiKey: string;
+      };
+      replayDetected: boolean;
+      usedOtpTracking: string;
+    };
+
+    expect(json.ok).toBe(true);
+    expect(json.computedOtp).toMatch(/^\d{6}$/);
+    expect(json.victimLogin.authenticatedAs).toBe("seed_alice");
+    expect(json.attackerReplay.authenticatedAs).toBe("seed_alice");
+    // 脆弱性の核心: 同じ counter で 2 セッション発行
+    expect(json.victimLogin.counterMatched).toBe(json.attackerReplay.counterMatched);
+    // 漏えい想定データが揃っている
+    expect(json.leakedToAttacker.userId).toBe(1);
+    expect(json.leakedToAttacker.email).toBe("alice@victim.local");
+    expect(json.leakedToAttacker.demoBalance).toBe("$12,345.67");
+    expect(json.leakedToAttacker.demoApiKey).toContain("REDACTED");
+    expect(json.replayDetected).toBe(false);
+    expect(json.usedOtpTracking).toBe("absent");
+
+    // 教材ヘッダ
+    expect(res.headers.get("X-Computed-OTP")).toBe(json.computedOtp);
+    expect(res.headers.get("X-Replay-Detected")).toBe("false");
+    expect(res.headers.get("X-Counter")).toBe(String(json.totpCounter));
+  });
+
+  it("学習者が secret を明示的に渡すと secretUsed=<learner-provided> になる", async () => {
+    const app = createApp();
+    const res = await app.request("/totp/login-replay", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "seed_admin", secret: DEMO_SECRET }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      ok: boolean;
+      secretUsed: string;
+      leakedToAttacker: { userId: number; demoBalance: string };
+    };
+    expect(json.ok).toBe(true);
+    expect(json.secretUsed).toBe("<learner-provided>");
+    expect(json.leakedToAttacker.userId).toBe(4);
+    expect(json.leakedToAttacker.demoBalance).toBe("$1,000,000.00");
+  });
+
+  it("学習者が現在時刻の正しい OTP を code として送ってもリプレイが成立する", async () => {
+    const app = createApp();
+    const counter = currentCounter();
+    const code = computeTotp(DEMO_SECRET, counter).code;
+    const res = await app.request("/totp/login-replay", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "seed_bob", secret: DEMO_SECRET, code }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      ok: boolean;
+      computedOtp: string;
+      victimLogin: { counterMatched: number };
+      attackerReplay: { counterMatched: number };
+    };
+    expect(json.ok).toBe(true);
+    expect(json.computedOtp).toBe(code);
+    expect(json.victimLogin.counterMatched).toBe(json.attackerReplay.counterMatched);
+  });
+
+  it("シードに存在しないユーザー名は 401 を返す", async () => {
+    const app = createApp();
+    const res = await app.request("/totp/login-replay", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "ghost_user" }),
+    });
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as {
+      ok: boolean;
+      error: string;
+      requestedUsername: string;
+    };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("invalid credentials");
+    expect(json.requestedUsername).toBe("ghost_user");
+  });
+
+  it("username 欠如時は 400 を返す", async () => {
+    const app = createApp();
+    const res = await app.request("/totp/login-replay", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { ok: boolean; error: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("username");
+  });
+
+  it("invalid JSON body は 400 を返す", async () => {
+    const app = createApp();
+    const res = await app.request("/totp/login-replay", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { ok: boolean; error: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toBe("invalid_json_body");
+  });
+});

--- a/services/victim-web/src/index.ts
+++ b/services/victim-web/src/index.ts
@@ -18,6 +18,7 @@ import { jwtVulnRoutes } from "./routes/jwt-vuln.js";
 import { oauthVulnRoutes } from "./routes/oauth-vuln.js";
 import { rbacVulnRoutes } from "./routes/rbac-vuln.js";
 import { sessionVulnRoutes } from "./routes/session-vuln.js";
+import { totpVulnRoutes } from "./routes/totp-vuln.js";
 
 const app = new Hono();
 
@@ -29,6 +30,7 @@ app.route("/jwt", jwtVulnRoutes);
 app.route("/oauth", oauthVulnRoutes);
 app.route("/rbac", rbacVulnRoutes);
 app.route("/session", sessionVulnRoutes);
+app.route("/totp", totpVulnRoutes);
 
 // PORT は docker container 環境用 (compose で PORT=4001 を渡す)。
 // host で `dev:no-docker` を実行すると vite が PORT=3000 を環境にセットするため、

--- a/services/victim-web/src/routes/totp-vuln.ts
+++ b/services/victim-web/src/routes/totp-vuln.ts
@@ -1,0 +1,216 @@
+/**
+ * 脆弱エンドポイント: TOTP Replay (CWE-294 / CAPEC-60)
+ *
+ * 【教育目的専用】
+ * このファイルは OSI 参照アプリの教材機能として、
+ * victim-net 内の固定シードデータに対する概念実証を提供します。
+ *
+ * - 外部ネットワークへのリクエストは行いません
+ * - 実 CVE のエクスプロイトコードは含みません
+ * - victim-net 外での動作は想定していません
+ *
+ * 対応 CWE: CWE-294 (Authentication Bypass by Capture-Replay)
+ * 対応 CAPEC: CAPEC-60
+ * 堅牢実装: server/routes/mfa-totp.ts (used_otps テーブルで再使用拒否)
+ * 関連設計書: DESIGN/04-safety-guardrails.md, DESIGN/32-victim-web-spec.md §4.7,
+ *             DESIGN/35-attack-storyboard.md (Phase 2 PR-4 で追記)
+ */
+import { Hono } from "hono";
+import { computeTotp, currentCounter, verifyTotpWithDetail } from "../utils/totp.js";
+
+export const totpVulnRoutes = new Hono();
+
+/** 固定 demo secret (ASCII "Hi"+padding 等価の base32)。学習者が secret を省略した場合に使用。 */
+const DEMO_TOTP_SECRET = "JBSWY3DPEHPK3PXP";
+
+/**
+ * 教材用シードユーザー + 漏えい想定データ。
+ * 「攻撃者がアカウント乗っ取りで取得できるデータ」を 1 リクエストで可視化するため、
+ * 各ユーザーに擬似個人情報 (email / 残高 / demoApiKey) を持たせる。
+ * すべて _DEMO_ / @victim.local / REDACTED マーカー入りで、本物の secret は含まない。
+ */
+const SEED_USER_PROFILES: Readonly<
+  Record<
+    string,
+    Readonly<{
+      id: number;
+      username: string;
+      email: string;
+      fullName: string;
+      lastLogin: string;
+      demoBalance: string;
+      demoApiKey: string;
+    }>
+  >
+> = {
+  seed_alice: {
+    id: 1,
+    username: "seed_alice",
+    email: "alice@victim.local",
+    fullName: "Alice Demo",
+    lastLogin: "2026-05-09T22:14:03Z",
+    demoBalance: "$12,345.67",
+    demoApiKey: "sk_demo_alice_REDACTED_aXX1",
+  },
+  seed_bob: {
+    id: 2,
+    username: "seed_bob",
+    email: "bob@victim.local",
+    fullName: "Bob Demo",
+    lastLogin: "2026-05-09T18:02:11Z",
+    demoBalance: "$987.65",
+    demoApiKey: "sk_demo_bob_REDACTED_bYY2",
+  },
+  seed_admin: {
+    id: 4,
+    username: "seed_admin",
+    email: "admin@victim.local",
+    fullName: "Admin Demo",
+    lastLogin: "2026-05-10T07:55:42Z",
+    demoBalance: "$1,000,000.00",
+    demoApiKey: "sk_demo_admin_REDACTED_dZZ4",
+  },
+};
+
+interface ParsedRequest {
+  username: string;
+  secret: string;
+  /** true なら学習者が secret を明示的に送信した。false なら demo default 使用 */
+  secretFromLearner: boolean;
+  providedCode: string | null;
+}
+
+function parseRequest(body: unknown): { ok: true; data: ParsedRequest } | { ok: false; error: string } {
+  if (typeof body !== "object" || body === null) {
+    return { ok: false, error: "request body must be a JSON object" };
+  }
+  const obj = body as Record<string, unknown>;
+  const usernameRaw = obj.username;
+  if (typeof usernameRaw !== "string" || usernameRaw.length === 0) {
+    return { ok: false, error: "username is required and must be a non-empty string" };
+  }
+  const secretRaw = obj.secret;
+  const secretFromLearner = typeof secretRaw === "string" && secretRaw.length > 0;
+  const secret = secretFromLearner ? (secretRaw as string) : DEMO_TOTP_SECRET;
+  const codeRaw = obj.code;
+  const providedCode = typeof codeRaw === "string" && codeRaw.length > 0 ? codeRaw : null;
+  return { ok: true, data: { username: usernameRaw, secret, secretFromLearner, providedCode } };
+}
+
+/**
+ * 脆弱: 学習者が送った username + secret を使い、victim が現在時刻 OTP を計算し、
+ * 同じ OTP で 2 連続検証して両方 success を返す。
+ * used_otps テーブルを持たない実装の脅威を 1 リクエストで体感させる (CWE-294)。
+ *
+ * 期待入力: POST /totp/login-replay
+ *   body: { "username": "<seed_alice|seed_bob|seed_admin>", "secret"?: "<base32>", "code"?: "<6digits>" }
+ * 期待挙動:
+ *   - 既知 username + secret → 200 + computedOtp + victimLogin + attackerReplay + leakedToAttacker
+ *   - 未知 username → 401
+ *   - body 欠如 / 型違反 → 400
+ *   - invalid JSON body → 400
+ *
+ * 堅牢実装 (server/routes/mfa-totp.ts) では (user_id, counter) を used_otps に記録し、
+ * 同一 counter の再使用を拒否するため、第 2 回目の検証は failed になる。
+ */
+totpVulnRoutes.post("/login-replay", async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ ok: false, error: "invalid_json_body" }, 400);
+  }
+
+  const parsed = parseRequest(body);
+  if (!parsed.ok) {
+    return c.json({ ok: false, error: parsed.error }, 400);
+  }
+  const { username, secret, secretFromLearner, providedCode } = parsed.data;
+
+  const profile = SEED_USER_PROFILES[username];
+  if (!profile) {
+    return c.json(
+      { ok: false, error: "invalid credentials", requestedUsername: username },
+      401,
+    );
+  }
+
+  // ── 脆弱性の核心 ─────────────────────────────────────────────────
+  // victim が「攻撃者が観測した OTP」のメタファーとして現在時刻 OTP を生成し、
+  // 同じ OTP で 2 連続検証する。used_otps を記録しないため両方 success になる。
+  // ───────────────────────────────────────────────────────────────
+  const counter = currentCounter();
+  const computed = computeTotp(secret, counter);
+  const otpToReplay = providedCode ?? computed.code;
+
+  const firstVerify = verifyTotpWithDetail(secret, otpToReplay);
+  const secondVerify = verifyTotpWithDetail(secret, otpToReplay);
+
+  // 両方検証成功 = 脆弱性が成立した
+  const replaySucceeded =
+    firstVerify.match !== null &&
+    secondVerify.match !== null &&
+    firstVerify.match.counter === secondVerify.match.counter;
+
+  if (!replaySucceeded) {
+    // providedCode が wrong などで一致しなかった場合のみ通る (教材的にはレア)
+    return c.json(
+      {
+        ok: false,
+        error: "otp_did_not_verify",
+        computedOtp: computed.code,
+        firstVerify: { match: firstVerify.match !== null },
+        secondVerify: { match: secondVerify.match !== null },
+        note: "Provided OTP did not match the current ±1 window. Try omitting `code` so victim computes the current OTP.",
+      },
+      400,
+    );
+  }
+
+  const issuedAt = new Date().toISOString();
+  const victimLogin = {
+    authenticatedAs: profile.username,
+    sessionId: `VICTIM_SESSION_${profile.username}_${counter.toString(36)}`,
+    bearerToken: `VICTIM_TOKEN_${profile.username}_${Date.now().toString(36)}_a`,
+    issuedAt,
+    counterMatched: firstVerify.match!.counter,
+  };
+  const attackerReplay = {
+    authenticatedAs: profile.username, // ← 攻撃者が被害者として認証された
+    sessionId: `ATTACKER_SESSION_${profile.username}_${counter.toString(36)}`,
+    bearerToken: `ATTACKER_TOKEN_${profile.username}_${Date.now().toString(36)}_b`,
+    issuedAt,
+    counterMatched: secondVerify.match!.counter,
+  };
+
+  const leakedToAttacker = {
+    userId: profile.id,
+    username: profile.username,
+    email: profile.email,
+    fullName: profile.fullName,
+    lastLogin: profile.lastLogin,
+    demoBalance: profile.demoBalance,
+    demoApiKey: profile.demoApiKey,
+  };
+
+  // 教材ヒント用ヘッダ (storyboard の data-leak visual で参照しやすい)
+  c.header("X-Computed-OTP", computed.code);
+  c.header("X-Replay-Detected", "false");
+  c.header("X-Counter", counter.toString());
+
+  return c.json({
+    ok: true,
+    computedOtp: computed.code,
+    totpCounter: counter,
+    secretUsed: secretFromLearner ? "<learner-provided>" : "<demo-default>",
+    victimLogin,
+    attackerReplay,
+    leakedToAttacker,
+    replayDetected: false,
+    usedOtpTracking: "absent",
+    note:
+      "CWE-294: Same OTP authenticated TWO independent sessions. The attacker now holds equivalent " +
+      "account access as the victim. A defended server would record (user_id, counter) on first verify " +
+      "and reject the second (see server/routes/mfa-totp.ts for the recommended implementation pattern).",
+  });
+});

--- a/services/victim-web/src/utils/totp.ts
+++ b/services/victim-web/src/utils/totp.ts
@@ -1,0 +1,120 @@
+/**
+ * RFC 4648 Base32 + RFC 6238 TOTP — victim-web 側のローカルコピー。
+ *
+ * 教材構造上、server 本体 (server/utils/totp.ts) には依存させず、
+ * victim を独立した「脆弱な別アプリ」として扱う方針 (DESIGN/35 設計判断)。
+ * 実装は server/utils/totp.ts と等価で、外部依存は node:crypto のみ。
+ *
+ * このコピーが脆弱な実装の TOTP 検証コアロジックを提供し、
+ * routes/totp-vuln.ts の login-replay エンドポイントが used-OTP 記録なしで
+ * 同じコードを 2 連続検証することで CWE-294 を再現する。
+ */
+import crypto from "node:crypto";
+
+export const TOTP_PERIOD = 30;
+export const TOTP_DIGITS = 6;
+export const TOTP_ALGORITHM = "SHA1";
+
+const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+export function base32Encode(buf: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let out = "";
+  for (const b of buf) {
+    value = (value << 8) | b;
+    bits += 8;
+    while (bits >= 5) {
+      out += BASE32_ALPHABET[(value >>> (bits - 5)) & 0x1f];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) out += BASE32_ALPHABET[(value << (5 - bits)) & 0x1f];
+  return out;
+}
+
+export function base32Decode(str: string): Buffer {
+  const clean = str.toUpperCase().replace(/=+$/, "").replace(/\s/g, "");
+  const bytes: number[] = [];
+  let bits = 0;
+  let value = 0;
+  for (const ch of clean) {
+    const idx = BASE32_ALPHABET.indexOf(ch);
+    if (idx < 0) throw new Error(`invalid base32 character: ${ch}`);
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      bytes.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(bytes);
+}
+
+export interface TotpDetail {
+  counter: number;
+  counterHex: string;
+  hmacHex: string;
+  offset: number;
+  truncatedHex: string;
+  binary: number;
+  code: string;
+}
+
+export function computeTotp(secret: string, counter: number): TotpDetail {
+  const key = base32Decode(secret);
+  const counterBuf = Buffer.alloc(8);
+  counterBuf.writeBigUInt64BE(BigInt(counter));
+  const hmac = crypto.createHmac("sha1", key).update(counterBuf).digest();
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const truncated = hmac.subarray(offset, offset + 4);
+  const binary =
+    ((truncated[0] & 0x7f) << 24) |
+    (truncated[1] << 16) |
+    (truncated[2] << 8) |
+    truncated[3];
+  const code = (binary % 10 ** TOTP_DIGITS).toString().padStart(TOTP_DIGITS, "0");
+  return {
+    counter,
+    counterHex: counterBuf.toString("hex"),
+    hmacHex: hmac.toString("hex"),
+    offset,
+    truncatedHex: truncated.toString("hex"),
+    binary,
+    code,
+  };
+}
+
+export function currentCounter(): number {
+  return Math.floor(Date.now() / 1000 / TOTP_PERIOD);
+}
+
+/**
+ * Verify a TOTP code with ±window time tolerance.
+ * Returns the matched TotpDetail or null.
+ *
+ * 注意: 本コピーは used-OTP tracking を持たない (CWE-294 の脆弱パスに使う)。
+ */
+export function verifyTotpWithDetail(
+  secret: string,
+  code: string,
+  window = 1,
+): { match: TotpDetail | null; attempts: TotpDetail[] } {
+  const base = currentCounter();
+  const attempts: TotpDetail[] = [];
+  let match: TotpDetail | null = null;
+  const providedBuf = Buffer.from(code, "utf8");
+  for (let i = -window; i <= window; i++) {
+    const d = computeTotp(secret, base + i);
+    attempts.push(d);
+    if (match) continue;
+    const expectedBuf = Buffer.from(d.code, "utf8");
+    if (
+      providedBuf.length === expectedBuf.length &&
+      crypto.timingSafeEqual(providedBuf, expectedBuf)
+    ) {
+      match = d;
+    }
+  }
+  return { match, attempts };
+}

--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -439,6 +439,80 @@ export interface AttackResult<TExtra = Record<string, never>> {
   extra?: TExtra;
 }
 
+/* ── Attack Storyboard (DESIGN/35) ── */
+
+/**
+ * シナリオ物語の登場人物。emoji avatar とハイライト色の選択に使う。
+ * StoryActorAvatar 以外のコンポーネントへの emoji 使用波及は禁止 (DESIGN/35 §9.5)。
+ */
+export type AttackStoryActor =
+  | "attacker"
+  | "victim"
+  | "server"
+  | "victim-srv"
+  | "narrator"
+  | "system";
+
+/** RawExchange 内の特定フィールドへの安定参照 (DESIGN/35 §7)。 */
+export interface RawExchangeRef {
+  pair: "browserToOrchestrator" | "orchestratorToVictim";
+  side: "request" | "response";
+  /** "line" | "body" | { header: string }。header は case-insensitive。 */
+  field: "line" | "body" | { header: string };
+}
+
+/** http-request / http-response visual 内の強調指示。 */
+export interface HttpHighlight {
+  target: "header" | "body-fragment" | "status";
+  /** ヘッダ名 or 検索文字列 */
+  match: string;
+  tooltipJa?: string;
+  tooltip?: string;
+}
+
+/**
+ * シーンの中央エリアに描画するビジュアル要素。タグ付きユニオン (DESIGN/35 §2.2)。
+ * raw exchange 不在時は visual を fallback 表示 (label のみ + プレースホルダ "—")。
+ */
+export type AttackStoryVisual =
+  | { type: "http-request"; sourceRef: RawExchangeRef; highlight?: HttpHighlight[] }
+  | { type: "http-response"; sourceRef: RawExchangeRef; highlight?: HttpHighlight[] }
+  | {
+      type: "data-leak";
+      label: string;
+      labelJa: string;
+      valueRef: RawExchangeRef;
+      severity?: "info" | "high" | "critical";
+    }
+  | { type: "code-defense"; codeHintIndex: number; lineHighlight?: [number, number] }
+  | {
+      type: "sequence-arrow";
+      from: AttackStoryActor;
+      to: AttackStoryActor;
+      label: string;
+      labelJa: string;
+      direction: "request" | "response";
+    }
+  | { type: "ascii"; content: string };
+
+/** 攻撃シナリオの 1 シーン (紙芝居の 1 ページ)。 */
+export interface AttackStoryScene {
+  /** story 配列内ユニーク。テスト・キーボード遷移で使用 */
+  id: string;
+  title: string;
+  titleJa: string;
+  actor: AttackStoryActor;
+  /** キャラ吹き出し (一人称・常体)。null=純ナレーション */
+  speech?: { ja: string; en: string } | null;
+  /** 第三者ナレーション (敬体)。シーン下部に表示 */
+  narration?: { ja: string; en: string } | null;
+  visual?: AttackStoryVisual;
+  /** 同時にハイライトする他アクター */
+  highlightActors?: AttackStoryActor[];
+  /** auto-play 時の表示時間 (ms)。未指定は story 全体のデフォルト */
+  durationMs?: number;
+}
+
 /**
  * 攻撃シナリオのメタ情報。
  * tabId は src/types/security.ts の AuthSubView 型と一致させる (循環参照回避のため string)。
@@ -499,6 +573,15 @@ export interface AttackScenarioMeta {
     headers?: Record<string, string>;
     body?: string;
   };
+
+  /**
+   * 紙芝居型物語シーン (DESIGN/35)。未指定/空配列のシナリオは AttackStoryView を非表示。
+   * 指定時は AttackPanel 内で classic timeline と共存表示される (DESIGN/35 §4.2)。
+   */
+  story?: AttackStoryScene[];
+
+  /** auto-play デフォルト ms (省略時 3000)。シナリオ単位で上書き可能 (DESIGN/35 §5.2)。 */
+  storyDefaultDurationMs?: number;
 }
 
 /* ── Live Attack: Orchestrator API (DESIGN/31) ── */

--- a/src/components/auth/MfaFlow.tsx
+++ b/src/components/auth/MfaFlow.tsx
@@ -11,7 +11,7 @@ import ViewModeToggle from "../shared/ViewModeToggle";
 import AttackPanel from "../shared/AttackPanel";
 import { getViewMode } from "../../state/attack-state";
 import { mfaScenarios } from "./attacks/scenarios/mfa-scenarios";
-import type { AttackResult } from "../../../shared/api-types";
+import type { AttackResult, OrchestratorExecResponse } from "../../../shared/api-types";
 import "./MfaFlow.css";
 
 const SCOPE = "mfa-totp";
@@ -471,6 +471,7 @@ export default function MfaFlow() {
         <AttackPanel
           tabId="mfa"
           scenarios={mfaScenarios}
+          allowedTargets={["victim-web"]}
           onRunScenario={async (s) => {
             const routeSuffix = ROUTE_BY_ID[s.id] ?? s.id.replace(/^mfa-/, "");
             const res = await apiPost<AttackResult>(
@@ -487,6 +488,46 @@ export default function MfaFlow() {
                 steps: [],
                 summaryJa: res.error ?? "実行エラー",
                 summary: res.error ?? "Execution error",
+              };
+            }
+            return res.data;
+          }}
+          onRunLiveScenario={async (s, payload) => {
+            const res = await apiPost<OrchestratorExecResponse>(
+              "/api/orchestrator/exec",
+              {
+                scenarioId: s.id,
+                target: payload.target,
+                request: payload.request,
+              },
+              "attack-mfa",
+            );
+            if (!res.data) {
+              const errMsg = res.error ?? "Execution error";
+              const friendlyJa =
+                errMsg === "victim_unreachable"
+                  ? "victim-web が起動していません。docker compose up -d victim-web または npm run dev:victim を実行してください。"
+                  : errMsg === "live_attack_disabled_in_production"
+                  ? "live モードは production 環境では無効です。"
+                  : errMsg === "phase_not_reached"
+                  ? "このシナリオは現在の Phase ではまだ live 化されていません。"
+                  : `実行エラー: ${errMsg}`;
+              const friendlyEn =
+                errMsg === "victim_unreachable"
+                  ? "victim-web is not reachable. Start it with `docker compose up -d victim-web` or `npm run dev:victim`."
+                  : errMsg === "live_attack_disabled_in_production"
+                  ? "Live mode is disabled in production."
+                  : errMsg === "phase_not_reached"
+                  ? "This scenario is not yet live in the current phase."
+                  : `Execution error: ${errMsg}`;
+              return {
+                scenarioId: s.id,
+                outcome: "error" as const,
+                startedAt: Date.now(),
+                finishedAt: Date.now(),
+                steps: [],
+                summaryJa: friendlyJa,
+                summary: friendlyEn,
               };
             }
             return res.data;

--- a/src/components/auth/attacks/scenarios/mfa-scenarios.ts
+++ b/src/components/auth/attacks/scenarios/mfa-scenarios.ts
@@ -118,6 +118,176 @@ async function defendedLoginStep2(challengeId: string, code: string) {
         kind: "defensive",
       },
     ],
+    // Phase 2 PoC: live attack 化された 5 件目 = Phase 2 完結シナリオ。
+    // 学習者は username + (任意 secret) を送信し、victim-web が現在時刻 OTP を計算 → 同じ OTP で
+    // 2 連続検証 → 両方 success を 1 リクエストで返す挙動を観察できる。leakedToAttacker フィールドで
+    // 「攻撃者が乗っ取りで取得できる擬似個人情報」を可視化する (DESIGN/35 §1)。
+    mode: "live",
+    liveTemplate: {
+      target: "victim-web",
+      method: "POST",
+      path: "/totp/login-replay",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      // secret 省略時は victim 内部の DEMO_TOTP_SECRET を使用。
+      // 学習者は username を seed_alice / seed_bob / seed_admin に変えて漏えい対象を切り替え可能。
+      body: JSON.stringify({ username: "seed_alice" }),
+    },
+    // Phase 2 PR-4 で初導入された AttackStoryboard (DESIGN/35) の 7 シーンテンプレ。
+    // 攻撃の物語進行を紙芝居化し、leakedToAttacker の中身を data-leak visual で可視化する。
+    storyDefaultDurationMs: 4000,
+    story: [
+      {
+        id: "scene-1-setup",
+        title: "Target: alice's TOTP-protected account",
+        titleJa: "標的: alice の TOTP 保護アカウント",
+        actor: "attacker",
+        speech: {
+          ja: "alice のアカウントを狙う。MFA を破る方法を考えよう。",
+          en: "Targeting alice's account. Need to bypass her MFA.",
+        },
+        narration: {
+          ja: "攻撃者は被害者 alice のアカウントを乗っ取ろうとしています。alice は TOTP (RFC 6238) で MFA を有効化しており、ログインに 6 桁の OTP が要ります。",
+          en: "The attacker plans to take over alice's account. She has MFA enabled via TOTP (RFC 6238), requiring a 6-digit code on login.",
+        },
+        highlightActors: ["victim"],
+      },
+      {
+        id: "scene-2-observation",
+        title: "Shoulder-surfing the OTP",
+        titleJa: "OTP をショルダーサーフィン",
+        actor: "attacker",
+        speech: {
+          ja: "カフェの隣席で alice の画面が見えた。OTP は 123456 だ。",
+          en: "Caught alice's screen at the cafe. OTP is 123456.",
+        },
+        narration: {
+          ja: "TOTP は 30 秒ごとに更新されますが、±1 窓を許容するため最大 90 秒間は有効です。攻撃者はこの窓内に同じコードを再送する必要があります (RFC 6238 §5.2 はリプレイ対策を実装者に委ねています)。",
+          en: "TOTP rotates every 30s but a ±1 window leaves it valid for up to 90s. The attacker must replay within that window (RFC 6238 §5.2 leaves replay defense to the implementer).",
+        },
+        visual: {
+          type: "ascii",
+          content:
+            "alice's authenticator screen:\n" +
+            "  ┌──────────────┐\n" +
+            "  │   1 2 3 4 5 6 │   ← 攻撃者が観測\n" +
+            "  │ valid for ~30s│\n" +
+            "  └──────────────┘",
+        },
+      },
+      {
+        id: "scene-3-victim-login",
+        title: "Victim authenticates normally",
+        titleJa: "被害者が通常通りログイン",
+        actor: "victim",
+        speech: {
+          ja: "ログインしよう。OTP は 123456 だ。",
+          en: "Logging in. My OTP is 123456.",
+        },
+        narration: {
+          ja: "被害者 alice は通常通り MFA エンドポイントに OTP を送信し、サーバは「一致」と判定してセッションを発行します。ここまでは正規挙動です。",
+          en: "Alice submits her OTP to the MFA endpoint as usual. The server matches it and issues a session. So far this is normal behavior.",
+        },
+        visual: {
+          type: "sequence-arrow",
+          from: "victim",
+          to: "victim-srv",
+          label: "POST /totp/login-replay (alice's first login)",
+          labelJa: "POST /totp/login-replay (alice の正規ログイン)",
+          direction: "request",
+        },
+        highlightActors: ["victim-srv"],
+      },
+      {
+        id: "scene-4-replay",
+        title: "Attacker replays the same OTP",
+        titleJa: "攻撃者が同じ OTP でリプレイ",
+        actor: "attacker",
+        speech: {
+          ja: "90 秒以内に同じ OTP を送る。orchestrator を経由して victim-web に直接届ける。",
+          en: "Replaying the same OTP within 90s. Going through orchestrator to victim-web.",
+        },
+        narration: {
+          ja: "攻撃者は orchestrator/exec エンドポイント経由で同じ secret + 同じ counter の OTP を再送します。raw HTTP リクエストの body は学習者が編集できるようになっています。",
+          en: "The attacker re-sends the same OTP via orchestrator/exec, computed from the same secret + counter. The raw HTTP body is editable by the learner.",
+        },
+        visual: {
+          type: "http-request",
+          sourceRef: { pair: "orchestratorToVictim", side: "request", field: "line" },
+          highlight: [
+            {
+              target: "header",
+              match: "Content-Type",
+              tooltipJa: "JSON ボディとして username + secret を送信",
+              tooltip: "JSON body carrying username + secret",
+            },
+          ],
+        },
+      },
+      {
+        id: "scene-5-server-fails",
+        title: "Server fails to detect the replay",
+        titleJa: "サーバがリプレイを検知できない",
+        actor: "victim-srv",
+        speech: {
+          ja: "OTP は ±1 窓内で一致する。used_otps テーブル無いから、これも valid だ。",
+          en: "OTP matches within ±1 window. No used_otps table, so this one is valid too.",
+        },
+        narration: {
+          ja: "victim-web は 1 回目の検証で counter を記録せず、2 回目も同じ counter で検証成功してしまいます。CWE-294 はまさにこの「実装者がリプレイ防御を忘れた」状態を指しています。",
+          en: "victim-web does not persist (user_id, counter) on first verify, so the second call passes the same counter and returns success. This is exactly the CWE-294 'implementer forgot replay defense' pattern.",
+        },
+        visual: {
+          type: "data-leak",
+          label: "Computed OTP (X-Computed-OTP)",
+          labelJa: "計算された OTP (X-Computed-OTP)",
+          valueRef: {
+            pair: "orchestratorToVictim",
+            side: "response",
+            field: { header: "X-Computed-OTP" },
+          },
+          severity: "high",
+        },
+      },
+      {
+        id: "scene-6-leak",
+        title: "Account takeover succeeds",
+        titleJa: "アカウント乗っ取り成立",
+        actor: "attacker",
+        speech: {
+          ja: "alice として認証された。残高もメールも API キーも全部読める。",
+          en: "Authenticated as alice. Balance, email, API key — all mine to read.",
+        },
+        narration: {
+          ja: "victim から返ってきたレスポンスには「攻撃者が今この瞬間奪取したデータ」がそのまま入っています。実環境ではこのまま二要素認証完了 → 全ページにアクセス可能になります。",
+          en: "The response body contains exactly what the attacker just exfiltrated. In production this would complete the second factor and grant full account access.",
+        },
+        visual: {
+          type: "data-leak",
+          label: "Response body (leakedToAttacker)",
+          labelJa: "レスポンスボディ (leakedToAttacker)",
+          valueRef: { pair: "orchestratorToVictim", side: "response", field: "body" },
+          severity: "critical",
+        },
+      },
+      {
+        id: "scene-7-defense",
+        title: "Defense: record (user_id, counter)",
+        titleJa: "防御: (user_id, counter) を記録する",
+        actor: "narrator",
+        narration: {
+          ja: "堅牢実装は検証成功時に (user_id, counter) を used_otps テーブルへ記録し、同じ counter の再使用を拒否します。RFC 6238 §5.2 と NIST SP 800-63B §5.1.4.2 が同等の対策を勧告しています。",
+          en: "A defended server records (user_id, counter) on verification success and rejects any subsequent use of the same counter. RFC 6238 §5.2 and NIST SP 800-63B §5.1.4.2 prescribe the same control.",
+        },
+        visual: {
+          type: "code-defense",
+          codeHintIndex: 2,
+          lineHighlight: [9, 14],
+        },
+      },
+    ],
   },
   {
     id: "mfa-time-window-too-wide",

--- a/src/components/shared/AttackPanel.css
+++ b/src/components/shared/AttackPanel.css
@@ -109,3 +109,35 @@
   font-size: 0.78rem;
   padding: 8px 12px;
 }
+
+/* AttackStoryView 統合エリア (DESIGN/35 §4.2 step 5) */
+.attack-panel-storyboard {
+  margin-top: 4px;
+}
+
+/* 既存 AttackStepTimeline を story 持ちシナリオでは折りたたみ表示 (DESIGN/35 §4.2 step 6) */
+.attack-classic-timeline-fold {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  padding: 6px 10px;
+}
+
+.attack-classic-timeline-summary {
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  user-select: none;
+  padding: 2px 0;
+}
+
+.attack-classic-timeline-summary:hover {
+  color: var(--glow-color);
+}
+
+.attack-classic-timeline-fold[open] .attack-classic-timeline-summary {
+  margin-bottom: 8px;
+  border-bottom: 1px dashed var(--border-subtle);
+  color: var(--text-secondary);
+}

--- a/src/components/shared/AttackPanel.tsx
+++ b/src/components/shared/AttackPanel.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, Show, For } from "solid-js";
+import { createSignal, createEffect, createMemo, Show, For } from "solid-js";
 import { useI18n } from "../../i18n/context";
 import type {
   AttackScenarioMeta,
@@ -14,6 +14,7 @@ import AttackScenarioSelector from "./AttackScenarioSelector";
 import AttackStepTimeline from "./AttackStepTimeline";
 import AttackResultBanner from "./AttackResultBanner";
 import AttackDefensePanel from "./AttackDefensePanel";
+import AttackStoryView from "./AttackStoryView";
 import DataFlowPanel from "./DataFlowPanel";
 import RawHttpComposer from "./RawHttpComposer";
 import "./AttackPanel.css";
@@ -56,6 +57,8 @@ function AttackPanel(props: AttackPanelProps) {
   const isLiveMode = () => selectedScenario()?.mode === "live";
   const allowedTargets = (): VictimTarget[] =>
     props.allowedTargets ?? ["victim-web"];
+
+  const hasStory = createMemo(() => (selectedScenario()?.story?.length ?? 0) > 0);
 
   /* scenarios が変化したとき selectedId が無効/空なら最初のシナリオに同期 */
   createEffect(() => {
@@ -194,16 +197,44 @@ function AttackPanel(props: AttackPanelProps) {
           </div>
         </Show>
 
-        <div class="attack-panel-body">
-          {/* 5. タイムライン */}
-          <div class="attack-panel-timeline">
-            <AttackStepTimeline
-              steps={attackResult()?.steps ?? []}
-              running={running()}
+        {/* 5. ★NEW★ 攻撃ストーリーボード (DESIGN/35) — story 持ち + 結果あり時のみ表示 */}
+        <Show when={hasStory() && attackResult() !== null}>
+          <div class="attack-panel-storyboard">
+            <AttackStoryView
+              story={selectedScenario()!.story!}
+              rawExchange={rawExchange()}
+              codeHints={selectedScenario()!.codeHints}
+              defaultDurationMs={selectedScenario()!.storyDefaultDurationMs}
+              resetKey={selectedScenario()!.id}
             />
           </div>
+        </Show>
 
-          {/* 6. 防御策パネル */}
+        <div class="attack-panel-body">
+          {/* 6. タイムライン (story 持ちシナリオは折りたたみ、未対応シナリオは展開) */}
+          <div class="attack-panel-timeline">
+            <Show
+              when={hasStory()}
+              fallback={
+                <AttackStepTimeline
+                  steps={attackResult()?.steps ?? []}
+                  running={running()}
+                />
+              }
+            >
+              <details class="attack-classic-timeline-fold">
+                <summary class="attack-classic-timeline-summary">
+                  {t("詳細ステップを見る (probe / exploit / verify)", "Show detailed steps (probe / exploit / verify)")}
+                </summary>
+                <AttackStepTimeline
+                  steps={attackResult()?.steps ?? []}
+                  running={running()}
+                />
+              </details>
+            </Show>
+          </div>
+
+          {/* 7. 防御策パネル */}
           <div class="attack-panel-defense">
             <AttackDefensePanel
               scenario={selectedScenario()}

--- a/src/components/shared/AttackStoryControls.css
+++ b/src/components/shared/AttackStoryControls.css
@@ -1,0 +1,101 @@
+.story-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  user-select: none;
+}
+
+.story-controls-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.story-controls-btn:hover:not(:disabled) {
+  border-color: var(--glow-color);
+  color: var(--glow-color);
+  box-shadow: 0 0 8px var(--glow-color-dim);
+}
+
+.story-controls-btn:focus-visible {
+  outline: 2px solid var(--glow-color);
+  outline-offset: 2px;
+}
+
+.story-controls-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.story-controls-autoplay[data-on="true"] {
+  border-color: var(--color-attack-accent);
+  color: var(--color-attack-accent);
+  box-shadow: 0 0 8px var(--color-attack-accent-dim);
+}
+
+.story-controls-dots {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 0.25rem;
+}
+
+.story-controls-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  padding: 0;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.story-controls-dot:hover {
+  border-color: var(--glow-color);
+}
+
+.story-controls-dot[data-past="true"] {
+  background: var(--glow-color-dim);
+  border-color: var(--glow-color);
+}
+
+.story-controls-dot[data-active="true"] {
+  background: var(--color-attack-accent);
+  border-color: var(--color-attack-accent);
+  width: 12px;
+  height: 12px;
+  box-shadow: 0 0 8px var(--color-attack-accent-dim);
+}
+
+.story-controls-dot:focus-visible {
+  outline: 2px solid var(--glow-color);
+  outline-offset: 3px;
+}
+
+.story-controls-position {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  min-width: 80px;
+  text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .story-controls-btn,
+  .story-controls-dot {
+    transition: none;
+  }
+}

--- a/src/components/shared/AttackStoryControls.tsx
+++ b/src/components/shared/AttackStoryControls.tsx
@@ -1,0 +1,89 @@
+/**
+ * AttackStoryControls (DESIGN/35 §3, §5) — 攻撃ストーリーボードのナビゲーション UI。
+ *
+ * - ◄ ► ボタン (端で disabled)
+ * - dot indicator (シーン間ジャンプ + aria-current="step")
+ * - auto-play toggle (▶ / ⏸)
+ *
+ * StepControl.tsx の DNA を継承しつつ dot indicator + auto-play toggle を追加。
+ * DRY 化は Phase 3 以降で再評価。
+ */
+import { For } from "solid-js";
+import { useI18n } from "../../i18n/context";
+import "./AttackStoryControls.css";
+
+interface AttackStoryControlsProps {
+  current: number;
+  total: number;
+  autoPlay: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+  onJump: (index: number) => void;
+  onToggleAutoPlay: () => void;
+}
+
+export default function AttackStoryControls(props: AttackStoryControlsProps) {
+  const { t } = useI18n();
+
+  return (
+    <div class="story-controls" role="group" aria-label={t("ストーリーボード操作", "Storyboard controls")}>
+      <button
+        type="button"
+        class="story-controls-btn story-controls-prev"
+        disabled={props.current <= 0}
+        onClick={() => props.onPrev()}
+        aria-label={t("前のシーン", "Previous scene")}
+      >
+        ◄
+      </button>
+
+      <div class="story-controls-dots" role="tablist" aria-label={t("シーン一覧", "Scene list")}>
+        <For each={Array.from({ length: props.total })}>
+          {(_, i) => (
+            <button
+              type="button"
+              class="story-controls-dot"
+              data-active={i() === props.current ? "true" : "false"}
+              data-past={i() < props.current ? "true" : "false"}
+              role="tab"
+              aria-selected={i() === props.current}
+              aria-current={i() === props.current ? "step" : undefined}
+              aria-label={t(`シーン ${i() + 1} へ`, `Jump to scene ${i() + 1}`)}
+              onClick={() => props.onJump(i())}
+            />
+          )}
+        </For>
+      </div>
+
+      <span class="story-controls-position mono" aria-live="off">
+        {t(
+          `シーン ${props.current + 1} / ${props.total}`,
+          `Scene ${props.current + 1} of ${props.total}`,
+        )}
+      </span>
+
+      <button
+        type="button"
+        class="story-controls-btn story-controls-autoplay"
+        data-on={props.autoPlay ? "true" : "false"}
+        onClick={() => props.onToggleAutoPlay()}
+        aria-pressed={props.autoPlay}
+        aria-label={
+          props.autoPlay ? t("自動再生を停止", "Pause auto-play") : t("自動再生を開始", "Start auto-play")
+        }
+      >
+        {props.autoPlay ? "⏸" : "▶"}
+      </button>
+
+      <button
+        type="button"
+        class="story-controls-btn story-controls-next"
+        disabled={props.current >= props.total - 1}
+        onClick={() => props.onNext()}
+        aria-label={t("次のシーン", "Next scene")}
+      >
+        ►
+      </button>
+    </div>
+  );
+}

--- a/src/components/shared/AttackStoryScene.css
+++ b/src/components/shared/AttackStoryScene.css
@@ -1,0 +1,473 @@
+/* ── AttackStoryScene (DESIGN/35 §3, §9) ── */
+
+.story-scene {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.story-scene-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.story-scene-title {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+}
+
+/* ── アクター列 ── */
+.story-scene-actors {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 8px 4px;
+  background: var(--bg-secondary);
+  border-radius: var(--radius-sm);
+}
+
+.story-scene-actor-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  min-width: 90px;
+  position: relative;
+  transition: opacity var(--transition-fast);
+}
+
+.story-scene-actor-cell[data-active="false"] {
+  opacity: 0.35;
+}
+
+.story-scene-actor-cell[data-primary="true"] {
+  flex: 0 0 auto;
+}
+
+/* ── 吹き出し ── */
+.story-scene-speech-bubble {
+  position: relative;
+  max-width: 240px;
+  padding: 10px 12px;
+  background: var(--bg-card-hover);
+  border: 1px solid var(--border-active);
+  border-radius: var(--radius-md);
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  line-height: 1.45;
+  margin-top: 6px;
+  word-break: break-word;
+}
+
+.story-scene-speech-bubble::before {
+  content: "";
+  position: absolute;
+  top: -8px;
+  left: 24px;
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-bottom: 8px solid var(--border-active);
+}
+
+.story-scene-speech-bubble[data-actor="attacker"] {
+  border-color: var(--color-attack-accent-border);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+
+.story-scene-speech-bubble[data-actor="attacker"]::before {
+  border-bottom-color: var(--color-attack-accent-border);
+}
+
+.story-scene-speech-bubble[data-actor="victim"] {
+  border-color: var(--color-info-strong);
+}
+
+.story-scene-speech-bubble[data-actor="victim"]::before {
+  border-bottom-color: var(--color-info-strong);
+}
+
+.story-scene-speech-bubble[data-actor="server"],
+.story-scene-speech-bubble[data-actor="victim-srv"] {
+  border-color: var(--color-success-border);
+}
+
+.story-scene-speech-bubble[data-actor="server"]::before,
+.story-scene-speech-bubble[data-actor="victim-srv"]::before {
+  border-bottom-color: var(--color-success-border);
+}
+
+/* ── ナレーション ── */
+.story-scene-narration {
+  margin: 0;
+  padding: 10px 12px;
+  background: var(--bg-secondary);
+  border-left: 3px solid var(--text-muted);
+  border-radius: var(--radius-sm);
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* ── ビジュアル領域 ── */
+.story-scene-visual {
+  padding: 10px;
+  background: var(--bg-secondary);
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+
+/* ── http-request / http-response ── */
+.story-visual-http {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.story-visual-http-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.story-visual-http[data-kind="request"] .story-visual-http-label {
+  color: var(--color-attack-accent);
+}
+
+.story-visual-http[data-kind="response"] .story-visual-http-label {
+  color: var(--color-success);
+}
+
+.story-visual-http-line {
+  margin: 0;
+  padding: 6px 8px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  font-size: 0.78rem;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.story-visual-http-fallback {
+  padding: 10px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-align: center;
+  font-style: italic;
+}
+
+.story-visual-http-highlights {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.story-visual-http-highlight {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: baseline;
+  padding: 4px 8px;
+  background: var(--color-attack-accent-dim);
+  border-left: 3px solid var(--color-attack-accent);
+  border-radius: var(--radius-sm);
+  font-size: 0.78rem;
+}
+
+.story-visual-http-highlight-label {
+  color: var(--color-attack-accent);
+  font-weight: 700;
+}
+
+.story-visual-http-highlight-value {
+  color: var(--text-primary);
+  word-break: break-all;
+}
+
+.story-visual-http-highlight-tip {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.story-visual-http-body {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+}
+
+.story-visual-http-body-summary {
+  cursor: pointer;
+  padding: 6px 10px;
+  font-size: 0.75rem;
+  color: var(--glow-color);
+  font-family: var(--font-mono);
+}
+
+.story-visual-http-body-summary:hover {
+  text-decoration: underline;
+}
+
+.story-visual-http-body-content {
+  margin: 0;
+  padding: 8px 10px;
+  font-size: 0.75rem;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-all;
+  border-top: 1px solid var(--border-subtle);
+}
+
+/* ── data-leak ── */
+.story-visual-data-leak {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  background: var(--color-attack-accent-dim);
+  border: 2px solid var(--color-attack-accent);
+  border-radius: var(--radius-md);
+}
+
+.story-visual-data-leak[data-severity="critical"] {
+  animation: storyLeakPulse 1.4s ease-in-out infinite;
+}
+
+.story-visual-data-leak[data-severity="info"] {
+  background: var(--color-info-light);
+  border-color: var(--color-info);
+}
+
+.story-visual-data-leak-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.story-visual-data-leak-value {
+  font-size: 0.95rem;
+  color: var(--color-attack-accent);
+  font-weight: 700;
+  word-break: break-all;
+}
+
+.story-visual-data-leak[data-severity="info"] .story-visual-data-leak-value {
+  color: var(--color-info);
+}
+
+.story-visual-data-leak-fallback {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+@keyframes storyLeakPulse {
+  0%, 100% { box-shadow: 0 0 0 0 var(--color-attack-accent-dim); }
+  50% { box-shadow: 0 0 0 8px transparent; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .story-visual-data-leak[data-severity="critical"] {
+    animation: none;
+  }
+}
+
+/* ── code-defense ── */
+.story-visual-code-defense {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.story-visual-code-defense-label {
+  font-size: 0.78rem;
+  color: var(--color-success);
+  font-weight: 700;
+}
+
+.story-visual-code-defense-lang {
+  margin-left: 6px;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+.story-visual-code-defense-code {
+  margin: 0;
+  padding: 8px 0;
+  background: var(--bg-card);
+  border: 1px solid var(--color-success-border);
+  border-radius: var(--radius-sm);
+  font-size: 0.74rem;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.story-visual-code-defense-line {
+  display: flex;
+  gap: 10px;
+  padding: 1px 8px;
+}
+
+.story-visual-code-defense-line[data-highlight="true"] {
+  background: var(--color-success-light);
+  border-left: 3px solid var(--color-success);
+  padding-left: 5px;
+}
+
+.story-visual-code-defense-line-num {
+  color: var(--text-muted);
+  user-select: none;
+  min-width: 22px;
+  text-align: right;
+}
+
+.story-visual-code-defense-line-text {
+  color: var(--text-primary);
+  white-space: pre;
+}
+
+.story-visual-code-defense-empty {
+  padding: 10px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-style: italic;
+  text-align: center;
+}
+
+/* ── sequence-arrow ── */
+.story-visual-sequence-arrow {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px;
+}
+
+.story-visual-sequence-arrow-line {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.story-visual-sequence-arrow-label {
+  font-size: 0.78rem;
+  color: var(--text-primary);
+}
+
+.story-visual-sequence-arrow-shaft {
+  font-size: 1.2rem;
+  color: var(--glow-color);
+  letter-spacing: -2px;
+}
+
+.story-visual-sequence-arrow[data-direction="response"] .story-visual-sequence-arrow-shaft {
+  color: var(--color-success);
+}
+
+/* ── ascii ── */
+.story-visual-ascii {
+  margin: 0;
+  padding: 8px 10px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-primary);
+  white-space: pre;
+  overflow-x: auto;
+}
+
+/* ── StoryActorAvatar (内部用、本ファイルで co-located) ── */
+.story-actor-avatar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 80px;
+  padding: 6px 4px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  transition: all var(--transition-fast);
+}
+
+.story-actor-avatar[data-active="true"] {
+  border-color: var(--actor-color, var(--glow-color));
+  box-shadow: 0 0 12px var(--actor-color-dim, var(--glow-color-dim));
+}
+
+.story-actor-avatar[data-actor="attacker"] {
+  --actor-color: var(--color-attack-accent);
+  --actor-color-dim: var(--color-attack-accent-dim);
+}
+
+.story-actor-avatar[data-actor="victim"] {
+  --actor-color: var(--color-info);
+  --actor-color-dim: var(--color-info-light);
+}
+
+.story-actor-avatar[data-actor="server"] {
+  --actor-color: var(--color-success);
+  --actor-color-dim: var(--color-success-dim);
+}
+
+.story-actor-avatar[data-actor="victim-srv"] {
+  --actor-color: var(--color-attack-accent);
+  --actor-color-dim: var(--color-attack-accent-dim);
+}
+
+.story-actor-avatar[data-actor="narrator"] {
+  --actor-color: var(--text-muted);
+  --actor-color-dim: rgba(85, 102, 119, 0.2);
+}
+
+.story-actor-avatar[data-actor="system"] {
+  --actor-color: var(--glow-color);
+  --actor-color-dim: var(--glow-color-dim);
+}
+
+.story-actor-emoji {
+  font-size: 1.6rem;
+  line-height: 1;
+  text-align: center;
+}
+
+.story-actor-name {
+  font-size: 0.66rem;
+  color: var(--text-muted);
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.story-actor-avatar[data-active="true"] .story-actor-name {
+  color: var(--actor-color);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .story-actor-avatar {
+    transition: none;
+  }
+  .story-scene-actor-cell {
+    transition: none;
+  }
+}

--- a/src/components/shared/AttackStoryScene.tsx
+++ b/src/components/shared/AttackStoryScene.tsx
@@ -1,0 +1,324 @@
+/**
+ * AttackStoryScene (DESIGN/35 §3.3) — 紙芝居の 1 シーン描画。
+ *
+ * 構成: タイトル → アクター + 吹き出し → ビジュアル (variant 別) → ナレーション。
+ * 各 visual は `<Switch><Match>` で分岐し、raw exchange 不在時は label + "—" にフォールバック。
+ */
+import { Show, Switch, Match, For, createMemo } from "solid-js";
+import { Motion } from "solid-motionone";
+import { useI18n } from "../../i18n/context";
+import StoryActorAvatar from "./StoryActorAvatar";
+import { resolveRawRef } from "../../utils/story-resolver";
+import type {
+  AttackStoryScene,
+  AttackStoryActor,
+  AttackStoryVisual,
+  RawExchange,
+} from "../../../shared/api-types";
+import "./AttackStoryScene.css";
+
+interface AttackStorySceneProps {
+  scene: AttackStoryScene;
+  rawExchange?: RawExchange | null;
+  /** code-defense visual で参照する codeHints (シナリオ単位)。 */
+  codeHints?: { lang: string; label: string; code: string }[];
+  /** visible actors (highlight 計算用)。空配列なら全アクター候補をデフォルト表示。 */
+  visibleActors?: AttackStoryActor[];
+}
+
+const ALL_ACTORS_ORDER: AttackStoryActor[] = [
+  "attacker",
+  "system",
+  "server",
+  "victim-srv",
+  "victim",
+  "narrator",
+];
+
+export default function AttackStoryScene(props: AttackStorySceneProps) {
+  const { t } = useI18n();
+
+  const actorsToShow = createMemo<AttackStoryActor[]>(() => {
+    const set = new Set<AttackStoryActor>();
+    set.add(props.scene.actor);
+    for (const a of props.scene.highlightActors ?? []) set.add(a);
+    if (props.visibleActors) {
+      for (const a of props.visibleActors) set.add(a);
+    }
+    return ALL_ACTORS_ORDER.filter((a) => set.has(a));
+  });
+
+  const isActive = (actor: AttackStoryActor) =>
+    actor === props.scene.actor ||
+    (props.scene.highlightActors ?? []).includes(actor);
+
+  return (
+    <Motion
+      class="story-scene"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.2, easing: "ease-out" }}
+    >
+      <div class="story-scene-title-row">
+        <h4 class="story-scene-title">
+          {t(props.scene.titleJa, props.scene.title)}
+        </h4>
+      </div>
+
+      {/* アクター列 + 主役の吹き出し */}
+      <div class="story-scene-actors">
+        <For each={actorsToShow()}>
+          {(a) => (
+            <div
+              class="story-scene-actor-cell"
+              data-active={isActive(a) ? "true" : "false"}
+              data-primary={a === props.scene.actor ? "true" : "false"}
+            >
+              <StoryActorAvatar actor={a} active={isActive(a)} />
+              <Show when={a === props.scene.actor && props.scene.speech}>
+                <div
+                  class="story-scene-speech-bubble"
+                  data-actor={a}
+                  role="note"
+                >
+                  {t(props.scene.speech!.ja, props.scene.speech!.en)}
+                </div>
+              </Show>
+            </div>
+          )}
+        </For>
+      </div>
+
+      {/* 中央ビジュアル */}
+      <Show when={props.scene.visual}>
+        <div class="story-scene-visual">
+          <SceneVisual
+            visual={props.scene.visual!}
+            rawExchange={props.rawExchange ?? null}
+            codeHints={props.codeHints}
+          />
+        </div>
+      </Show>
+
+      {/* 第三者ナレーション */}
+      <Show when={props.scene.narration}>
+        <p class="story-scene-narration">
+          {t(props.scene.narration!.ja, props.scene.narration!.en)}
+        </p>
+      </Show>
+    </Motion>
+  );
+}
+
+interface SceneVisualProps {
+  visual: AttackStoryVisual;
+  rawExchange: RawExchange | null;
+  codeHints?: { lang: string; label: string; code: string }[];
+}
+
+function SceneVisual(props: SceneVisualProps) {
+  return (
+    <Switch>
+      <Match when={props.visual.type === "http-request" || props.visual.type === "http-response"}>
+        <HttpVisual
+          visual={props.visual as Extract<AttackStoryVisual, { type: "http-request" | "http-response" }>}
+          rawExchange={props.rawExchange}
+        />
+      </Match>
+
+      <Match when={props.visual.type === "data-leak"}>
+        <DataLeakVisual
+          visual={props.visual as Extract<AttackStoryVisual, { type: "data-leak" }>}
+          rawExchange={props.rawExchange}
+        />
+      </Match>
+
+      <Match when={props.visual.type === "code-defense"}>
+        <CodeDefenseVisual
+          visual={props.visual as Extract<AttackStoryVisual, { type: "code-defense" }>}
+          codeHints={props.codeHints}
+        />
+      </Match>
+
+      <Match when={props.visual.type === "sequence-arrow"}>
+        <SequenceArrowVisual
+          visual={props.visual as Extract<AttackStoryVisual, { type: "sequence-arrow" }>}
+        />
+      </Match>
+
+      <Match when={props.visual.type === "ascii"}>
+        <pre class="story-visual-ascii">
+          {(props.visual as Extract<AttackStoryVisual, { type: "ascii" }>).content}
+        </pre>
+      </Match>
+    </Switch>
+  );
+}
+
+function HttpVisual(props: {
+  visual: Extract<AttackStoryVisual, { type: "http-request" | "http-response" }>;
+  rawExchange: RawExchange | null;
+}) {
+  const { t } = useI18n();
+  const lineRef = createMemo(() => ({
+    ...props.visual.sourceRef,
+    field: "line" as const,
+  }));
+  const bodyRef = createMemo(() => ({
+    ...props.visual.sourceRef,
+    field: "body" as const,
+  }));
+
+  const line = createMemo(() => resolveRawRef(lineRef(), props.rawExchange));
+  const body = createMemo(() => resolveRawRef(bodyRef(), props.rawExchange));
+
+  const isRequest = () => props.visual.type === "http-request";
+
+  return (
+    <div class="story-visual-http" data-kind={isRequest() ? "request" : "response"}>
+      <div class="story-visual-http-label mono">
+        {isRequest() ? t("HTTP リクエスト", "HTTP request") : t("HTTP レスポンス", "HTTP response")}
+      </div>
+
+      <Show when={line()} fallback={<div class="story-visual-http-fallback">—</div>}>
+        <pre class="story-visual-http-line mono">{line()}</pre>
+      </Show>
+
+      <Show when={(props.visual.highlight ?? []).length > 0}>
+        <div class="story-visual-http-highlights">
+          <For each={props.visual.highlight}>
+            {(h) => {
+              const value = createMemo(() =>
+                h.target === "header"
+                  ? resolveRawRef(
+                      { ...props.visual.sourceRef, field: { header: h.match } },
+                      props.rawExchange,
+                    )
+                  : undefined,
+              );
+              return (
+                <div class="story-visual-http-highlight" data-target={h.target}>
+                  <span class="story-visual-http-highlight-label mono">
+                    {h.target === "header" ? `${h.match}:` : h.match}
+                  </span>
+                  <Show when={h.target === "header"} fallback={null}>
+                    <span class="story-visual-http-highlight-value mono">{value() ?? "—"}</span>
+                  </Show>
+                  <Show when={h.tooltipJa || h.tooltip}>
+                    <span class="story-visual-http-highlight-tip">
+                      {t(h.tooltipJa ?? "", h.tooltip ?? "")}
+                    </span>
+                  </Show>
+                </div>
+              );
+            }}
+          </For>
+        </div>
+      </Show>
+
+      <Show when={body()}>
+        <details class="story-visual-http-body">
+          <summary class="story-visual-http-body-summary">
+            {t("ボディを表示", "Show body")}
+          </summary>
+          <pre class="story-visual-http-body-content mono">{body()}</pre>
+        </details>
+      </Show>
+    </div>
+  );
+}
+
+function DataLeakVisual(props: {
+  visual: Extract<AttackStoryVisual, { type: "data-leak" }>;
+  rawExchange: RawExchange | null;
+}) {
+  const { t } = useI18n();
+  const value = createMemo(() => resolveRawRef(props.visual.valueRef, props.rawExchange));
+
+  return (
+    <div
+      class="story-visual-data-leak"
+      data-severity={props.visual.severity ?? "info"}
+      role="alert"
+    >
+      <div class="story-visual-data-leak-label">
+        {t(props.visual.labelJa, props.visual.label)}
+      </div>
+      <div class="story-visual-data-leak-value mono">
+        {value() ?? "—"}
+      </div>
+      <Show when={!value()}>
+        <div class="story-visual-data-leak-fallback">
+          {t("値が解決できませんでした (rawExchange 不在)", "Value unresolved (rawExchange missing)")}
+        </div>
+      </Show>
+    </div>
+  );
+}
+
+function CodeDefenseVisual(props: {
+  visual: Extract<AttackStoryVisual, { type: "code-defense" }>;
+  codeHints?: { lang: string; label: string; code: string }[];
+}) {
+  const { t } = useI18n();
+  const hint = createMemo(() => props.codeHints?.[props.visual.codeHintIndex]);
+  const lines = createMemo(() => (hint()?.code ?? "").split("\n"));
+  const hiRange = createMemo<[number, number]>(
+    () => props.visual.lineHighlight ?? [-1, -1],
+  );
+
+  return (
+    <Show
+      when={hint()}
+      fallback={
+        <div class="story-visual-code-defense-empty">
+          {t("対応する codeHint が見つかりません", "Corresponding codeHint not found")}
+        </div>
+      }
+    >
+      <div class="story-visual-code-defense">
+        <div class="story-visual-code-defense-label mono">
+          {hint()!.label}
+          <span class="story-visual-code-defense-lang">[{hint()!.lang}]</span>
+        </div>
+        <pre class="story-visual-code-defense-code mono">
+          <For each={lines()}>
+            {(line, i) => {
+              const [s, e] = hiRange();
+              const isHi = s >= 0 && i() >= s && i() <= e;
+              return (
+                <div class="story-visual-code-defense-line" data-highlight={isHi ? "true" : "false"}>
+                  <span class="story-visual-code-defense-line-num">{(i() + 1).toString().padStart(2, " ")}</span>
+                  <span class="story-visual-code-defense-line-text">{line}</span>
+                </div>
+              );
+            }}
+          </For>
+        </pre>
+      </div>
+    </Show>
+  );
+}
+
+function SequenceArrowVisual(props: {
+  visual: Extract<AttackStoryVisual, { type: "sequence-arrow" }>;
+}) {
+  const { t } = useI18n();
+  return (
+    <div
+      class="story-visual-sequence-arrow"
+      data-direction={props.visual.direction}
+    >
+      <StoryActorAvatar actor={props.visual.from} active />
+      <div class="story-visual-sequence-arrow-line">
+        <span class="story-visual-sequence-arrow-label mono">
+          {t(props.visual.labelJa, props.visual.label)}
+        </span>
+        <span class="story-visual-sequence-arrow-shaft" aria-hidden="true">
+          {props.visual.direction === "request" ? "──────►" : "◄──────"}
+        </span>
+      </div>
+      <StoryActorAvatar actor={props.visual.to} />
+    </div>
+  );
+}

--- a/src/components/shared/AttackStoryView.css
+++ b/src/components/shared/AttackStoryView.css
@@ -1,0 +1,54 @@
+/* ── AttackStoryView (DESIGN/35) ── */
+
+.attack-story-view {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-active);
+  border-radius: var(--radius-md);
+  outline: none;
+}
+
+.attack-story-view:focus-visible {
+  border-color: var(--glow-color);
+  box-shadow: 0 0 12px var(--glow-color-dim);
+}
+
+.attack-story-empty {
+  padding: 24px;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.attack-story-live {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* スクリーンリーダー専用 (視覚的に hidden) */
+.attack-story-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* prefers-reduced-motion 補助 (root に reduced-motion クラスが付与される) */
+.attack-story-view.reduced-motion *,
+.attack-story-view.reduced-motion *::before,
+.attack-story-view.reduced-motion *::after {
+  animation-duration: 0.001ms !important;
+  animation-delay: 0ms !important;
+  transition-duration: 0.001ms !important;
+  transition-delay: 0ms !important;
+}

--- a/src/components/shared/AttackStoryView.tsx
+++ b/src/components/shared/AttackStoryView.tsx
@@ -1,0 +1,216 @@
+/**
+ * AttackStoryView (DESIGN/35 §3.3, §4) — 攻撃シナリオ紙芝居の統合コンテナ。
+ *
+ * - シーン状態管理 (currentIndex, autoPlay)
+ * - キーボード操作 (← → Space Esc Home End)
+ * - prefers-reduced-motion 尊重 (auto-play デフォルト OFF)
+ * - aria-live="polite" でシーン切替アナウンス
+ * - story 末尾シーン到達で auto-play 自動停止
+ *
+ * 親 (AttackPanel) は scenario.story を渡すだけ。codeHints と rawExchange は
+ * code-defense / http-* / data-leak visual の解決に使われる (任意)。
+ */
+import {
+  createSignal,
+  createEffect,
+  createMemo,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
+import { useI18n } from "../../i18n/context";
+import AttackStoryScene from "./AttackStoryScene";
+import AttackStoryControls from "./AttackStoryControls";
+import type {
+  AttackStoryScene as AttackStorySceneType,
+  RawExchange,
+} from "../../../shared/api-types";
+import "./AttackStoryView.css";
+
+interface AttackStoryViewProps {
+  story: AttackStorySceneType[];
+  /** live モードでの raw exchange。null/undefined でも動作 (visual がフォールバック) */
+  rawExchange?: RawExchange | null;
+  /** code-defense visual の解決に使う codeHints */
+  codeHints?: { lang: string; label: string; code: string }[];
+  /** auto-play デフォルト ms (props 未指定時 3000) */
+  defaultDurationMs?: number;
+  /** シナリオ切替時のリセットトリガ (id 等を渡す) */
+  resetKey?: string | number;
+}
+
+export default function AttackStoryView(props: AttackStoryViewProps) {
+  const { t } = useI18n();
+  const [currentIndex, setCurrentIndex] = createSignal(0);
+  const [autoPlay, setAutoPlay] = createSignal(false);
+
+  let rootRef: HTMLDivElement | undefined;
+
+  const total = createMemo(() => props.story.length);
+  const currentScene = createMemo<AttackStorySceneType | undefined>(
+    () => props.story[currentIndex()],
+  );
+
+  const defaultDuration = () => props.defaultDurationMs ?? 3000;
+
+  function clampIndex(i: number): number {
+    if (total() === 0) return 0;
+    return Math.max(0, Math.min(total() - 1, i));
+  }
+
+  function goTo(i: number) {
+    setCurrentIndex(clampIndex(i));
+  }
+
+  function next() {
+    if (currentIndex() < total() - 1) {
+      setCurrentIndex(currentIndex() + 1);
+    }
+  }
+
+  function prev() {
+    if (currentIndex() > 0) {
+      setCurrentIndex(currentIndex() - 1);
+    }
+  }
+
+  function toggleAutoPlay() {
+    setAutoPlay(!autoPlay());
+  }
+
+  // resetKey 変更時に最初のシーンに戻す + auto-play 停止
+  createEffect(() => {
+    props.resetKey;
+    setCurrentIndex(0);
+    setAutoPlay(false);
+  });
+
+  // story が変わったとき currentIndex が範囲外なら 0 にリセット
+  createEffect(() => {
+    const len = total();
+    if (currentIndex() >= len) {
+      setCurrentIndex(0);
+    }
+  });
+
+  // auto-play timer 管理
+  createEffect(() => {
+    if (!autoPlay()) return;
+    const scene = currentScene();
+    if (!scene) return;
+    const ms = scene.durationMs ?? defaultDuration();
+    const timer = window.setTimeout(() => {
+      if (currentIndex() < total() - 1) {
+        setCurrentIndex(currentIndex() + 1);
+      } else {
+        setAutoPlay(false); // 末尾到達で自動停止
+      }
+    }, ms);
+    onCleanup(() => window.clearTimeout(timer));
+  });
+
+  // prefers-reduced-motion 検出 (auto-play default OFF)
+  onMount(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (mq.matches) {
+      setAutoPlay(false);
+      rootRef?.classList.add("reduced-motion");
+    }
+  });
+
+  // キーボード操作
+  function handleKeyDown(e: KeyboardEvent) {
+    switch (e.key) {
+      case "ArrowRight":
+      case " ":
+      case "Space":
+        e.preventDefault();
+        if (autoPlay()) setAutoPlay(false);
+        next();
+        break;
+      case "ArrowLeft":
+        e.preventDefault();
+        if (autoPlay()) setAutoPlay(false);
+        prev();
+        break;
+      case "Escape":
+        if (autoPlay()) {
+          e.preventDefault();
+          setAutoPlay(false);
+        }
+        break;
+      case "Home":
+        e.preventDefault();
+        setAutoPlay(false);
+        setCurrentIndex(0);
+        break;
+      case "End":
+        e.preventDefault();
+        setAutoPlay(false);
+        setCurrentIndex(total() - 1);
+        break;
+    }
+  }
+
+  // dot ジャンプ等の手動操作で auto-play を一時停止
+  function jump(i: number) {
+    if (autoPlay()) setAutoPlay(false);
+    goTo(i);
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      class="attack-story-view"
+      role="region"
+      aria-label={t("攻撃ストーリーボード", "Attack storyboard")}
+      tabindex="0"
+      onKeyDown={handleKeyDown}
+    >
+      <Show when={total() === 0}>
+        <div class="attack-story-empty">
+          {t("ストーリーが定義されていません", "No story defined for this scenario")}
+        </div>
+      </Show>
+
+      <Show when={total() > 0 && currentScene()}>
+        <div
+          class="attack-story-live"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {/* スクリーンリーダー向けのみ。視覚的には invisible */}
+          <span class="attack-story-sr-only">
+            {t(
+              `シーン ${currentIndex() + 1} / ${total()}: ${currentScene()!.titleJa}`,
+              `Scene ${currentIndex() + 1} of ${total()}: ${currentScene()!.title}`,
+            )}
+          </span>
+
+          <AttackStoryScene
+            scene={currentScene()!}
+            rawExchange={props.rawExchange}
+            codeHints={props.codeHints}
+          />
+        </div>
+
+        <AttackStoryControls
+          current={currentIndex()}
+          total={total()}
+          autoPlay={autoPlay()}
+          onPrev={() => {
+            if (autoPlay()) setAutoPlay(false);
+            prev();
+          }}
+          onNext={() => {
+            if (autoPlay()) setAutoPlay(false);
+            next();
+          }}
+          onJump={jump}
+          onToggleAutoPlay={toggleAutoPlay}
+        />
+      </Show>
+    </div>
+  );
+}

--- a/src/components/shared/StoryActorAvatar.tsx
+++ b/src/components/shared/StoryActorAvatar.tsx
@@ -1,0 +1,62 @@
+/**
+ * StoryActorAvatar (DESIGN/35 §9) — 攻撃ストーリーボードのキャラクター描画。
+ *
+ * 例外規約: emoji 使用は本コンポーネントに限定 (DESIGN/35 §9.5)。
+ * 他の Attack* コンポーネントへの絵文字波及は禁止。
+ *
+ * Phase 1: emoji 直接描画。将来 SVG 化する場合は本ファイル内で switch するだけで済む
+ * (シナリオデータは無変更で差し替え可能)。
+ */
+import { useI18n } from "../../i18n/context";
+import type { AttackStoryActor } from "../../../shared/api-types";
+
+interface StoryActorAvatarProps {
+  actor: AttackStoryActor;
+  active?: boolean;
+}
+
+const ACTOR_EMOJI: Record<AttackStoryActor, string> = {
+  attacker: "\u{1F608}",     // 😈
+  victim: "\u{1F464}",        // 👤
+  server: "\u{1F5A5}\u{FE0F}", // 🖥️
+  "victim-srv": "\u{1F513}", // 🔓
+  narrator: "\u{1F4E2}",      // 📢
+  system: "\u{1F310}",        // 🌐
+};
+
+const ACTOR_LABEL_JA: Record<AttackStoryActor, string> = {
+  attacker: "攻撃者",
+  victim: "被害者",
+  server: "サーバ",
+  "victim-srv": "脆弱 victim",
+  narrator: "解説",
+  system: "ネットワーク",
+};
+
+const ACTOR_LABEL_EN: Record<AttackStoryActor, string> = {
+  attacker: "Attacker",
+  victim: "Victim",
+  server: "Server",
+  "victim-srv": "Vulnerable victim",
+  narrator: "Narrator",
+  system: "Network",
+};
+
+export default function StoryActorAvatar(props: StoryActorAvatarProps) {
+  const { t } = useI18n();
+  const label = () => t(ACTOR_LABEL_JA[props.actor], ACTOR_LABEL_EN[props.actor]);
+
+  return (
+    <div
+      class="story-actor-avatar"
+      data-actor={props.actor}
+      data-active={props.active ? "true" : "false"}
+      aria-label={label()}
+    >
+      <span class="story-actor-emoji" aria-hidden="true">
+        {ACTOR_EMOJI[props.actor]}
+      </span>
+      <span class="story-actor-name">{label()}</span>
+    </div>
+  );
+}

--- a/src/components/shared/__tests__/AttackStoryScene.test.tsx
+++ b/src/components/shared/__tests__/AttackStoryScene.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@solidjs/testing-library";
+import { renderWithProviders } from "../../../test/render-with-providers";
+import AttackStoryScene from "../AttackStoryScene";
+import type { AttackStoryScene as Scene, RawExchange } from "../../../../shared/api-types";
+
+function makeRawExchange(): RawExchange {
+  return {
+    browserToOrchestrator: {
+      request: { line: "POST /api/x", headers: {}, body: null, bytesSent: 0 },
+      response: { line: "HTTP/1.1 200 OK", status: 200, headers: {}, body: null, bytesReceived: 0 },
+    },
+    orchestratorToVictim: {
+      request: {
+        line: "POST /totp/login-replay HTTP/1.1",
+        headers: { "Content-Type": "application/json", "X-Demo-Header": "demo-value" },
+        body: '{"username":"seed_alice"}',
+        bytesSent: 90,
+      },
+      response: {
+        line: "HTTP/1.1 200 OK",
+        status: 200,
+        headers: { "x-computed-otp": "123456" },
+        body: '{"ok":true,"computedOtp":"123456","leakedToAttacker":{"email":"alice@victim.local"}}',
+        bytesReceived: 110,
+      },
+      targetResolvedTo: "http://localhost:4001",
+    },
+    elapsedMs: 30,
+  };
+}
+
+describe("AttackStoryScene", () => {
+  it("renders title in Japanese by default", () => {
+    const scene: Scene = {
+      id: "x",
+      title: "Hello",
+      titleJa: "こんにちは",
+      actor: "attacker",
+      narration: { ja: "解説です", en: "Narration" },
+    };
+    renderWithProviders(() => <AttackStoryScene scene={scene} />);
+    expect(screen.getByText("こんにちは")).toBeTruthy();
+    expect(screen.getByText("解説です")).toBeTruthy();
+  });
+
+  it("renders speech bubble for primary actor", () => {
+    const scene: Scene = {
+      id: "x",
+      title: "Hello",
+      titleJa: "こんにちは",
+      actor: "attacker",
+      speech: { ja: "やった", en: "Done" },
+    };
+    renderWithProviders(() => <AttackStoryScene scene={scene} />);
+    expect(screen.getByText("やった")).toBeTruthy();
+  });
+
+  it("renders http-request visual with header highlight", () => {
+    const scene: Scene = {
+      id: "x",
+      title: "Req",
+      titleJa: "リクエスト",
+      actor: "attacker",
+      visual: {
+        type: "http-request",
+        sourceRef: { pair: "orchestratorToVictim", side: "request", field: "line" },
+        highlight: [{ target: "header", match: "X-Demo-Header" }],
+      },
+    };
+    renderWithProviders(() => <AttackStoryScene scene={scene} rawExchange={makeRawExchange()} />);
+    expect(screen.getByText("POST /totp/login-replay HTTP/1.1")).toBeTruthy();
+    expect(screen.getByText("demo-value")).toBeTruthy();
+  });
+
+  it("renders data-leak visual with resolved value", () => {
+    const scene: Scene = {
+      id: "x",
+      title: "Leak",
+      titleJa: "漏えい",
+      actor: "attacker",
+      visual: {
+        type: "data-leak",
+        label: "OTP",
+        labelJa: "OTP",
+        valueRef: { pair: "orchestratorToVictim", side: "response", field: { header: "X-Computed-OTP" } },
+        severity: "high",
+      },
+    };
+    renderWithProviders(() => <AttackStoryScene scene={scene} rawExchange={makeRawExchange()} />);
+    expect(screen.getByText("123456")).toBeTruthy();
+  });
+
+  it("renders data-leak fallback when rawExchange is null", () => {
+    const scene: Scene = {
+      id: "x",
+      title: "Leak",
+      titleJa: "漏えい",
+      actor: "attacker",
+      visual: {
+        type: "data-leak",
+        label: "OTP",
+        labelJa: "OTP",
+        valueRef: { pair: "orchestratorToVictim", side: "response", field: { header: "X-Computed-OTP" } },
+      },
+    };
+    renderWithProviders(() => <AttackStoryScene scene={scene} rawExchange={null} />);
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  it("renders code-defense visual using codeHints", () => {
+    const scene: Scene = {
+      id: "x",
+      title: "Defense",
+      titleJa: "防御策",
+      actor: "narrator",
+      visual: { type: "code-defense", codeHintIndex: 0, lineHighlight: [0, 1] },
+    };
+    const codeHints = [
+      { lang: "typescript", label: "Defended", code: "function ok() {\n  return true;\n}" },
+    ];
+    renderWithProviders(() => <AttackStoryScene scene={scene} codeHints={codeHints} />);
+    expect(screen.getByText("Defended")).toBeTruthy();
+    expect(screen.getByText("[typescript]")).toBeTruthy();
+    expect(screen.getByText("function ok() {")).toBeTruthy();
+  });
+
+  it("renders sequence-arrow visual", () => {
+    const scene: Scene = {
+      id: "x",
+      title: "Arrow",
+      titleJa: "矢印",
+      actor: "narrator",
+      visual: {
+        type: "sequence-arrow",
+        from: "attacker",
+        to: "server",
+        label: "POST /login",
+        labelJa: "POST /login",
+        direction: "request",
+      },
+    };
+    renderWithProviders(() => <AttackStoryScene scene={scene} />);
+    expect(screen.getByText("POST /login")).toBeTruthy();
+  });
+
+  it("renders ascii visual content", () => {
+    const scene: Scene = {
+      id: "x",
+      title: "Ascii",
+      titleJa: "アスキー図",
+      actor: "narrator",
+      visual: { type: "ascii", content: "alice -> server\nattacker -> alice" },
+    };
+    renderWithProviders(() => <AttackStoryScene scene={scene} />);
+    const pre = screen.getByText(/alice -> server/);
+    expect(pre).toBeTruthy();
+  });
+});

--- a/src/components/shared/__tests__/AttackStoryView.test.tsx
+++ b/src/components/shared/__tests__/AttackStoryView.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { screen, fireEvent } from "@solidjs/testing-library";
+import { renderWithProviders } from "../../../test/render-with-providers";
+import AttackStoryView from "../AttackStoryView";
+import type { AttackStoryScene } from "../../../../shared/api-types";
+
+const SAMPLE_STORY: AttackStoryScene[] = [
+  {
+    id: "s1",
+    title: "First scene",
+    titleJa: "シーン 1",
+    actor: "attacker",
+    speech: { ja: "攻撃開始", en: "Starting the attack" },
+  },
+  {
+    id: "s2",
+    title: "Second scene",
+    titleJa: "シーン 2",
+    actor: "victim",
+    speech: { ja: "気づかなかった", en: "Did not notice" },
+  },
+  {
+    id: "s3",
+    title: "Final scene",
+    titleJa: "シーン 3",
+    actor: "narrator",
+    narration: { ja: "防御策はこちら", en: "Defense steps below" },
+  },
+];
+
+describe("AttackStoryView", () => {
+  it("renders empty fallback when story is empty", () => {
+    renderWithProviders(() => <AttackStoryView story={[]} />);
+    expect(screen.getByText("ストーリーが定義されていません")).toBeTruthy();
+  });
+
+  it("renders the first scene by default", () => {
+    renderWithProviders(() => <AttackStoryView story={SAMPLE_STORY} />);
+    expect(screen.getByText("シーン 1")).toBeTruthy();
+    expect(screen.getByText("攻撃開始")).toBeTruthy();
+  });
+
+  it("disables prev button at first scene", () => {
+    renderWithProviders(() => <AttackStoryView story={SAMPLE_STORY} />);
+    const prev = screen.getByLabelText("前のシーン") as HTMLButtonElement;
+    expect(prev.disabled).toBe(true);
+  });
+
+  it("advances scene when next button clicked", () => {
+    renderWithProviders(() => <AttackStoryView story={SAMPLE_STORY} />);
+    const next = screen.getByLabelText("次のシーン");
+    fireEvent.click(next);
+    expect(screen.getByText("シーン 2")).toBeTruthy();
+    expect(screen.getByText("気づかなかった")).toBeTruthy();
+  });
+
+  it("disables next button at last scene", () => {
+    renderWithProviders(() => <AttackStoryView story={SAMPLE_STORY} />);
+    const next = screen.getByLabelText("次のシーン");
+    fireEvent.click(next);
+    fireEvent.click(next);
+    expect(screen.getByText("シーン 3")).toBeTruthy();
+    const nextBtn = screen.getByLabelText("次のシーン") as HTMLButtonElement;
+    expect(nextBtn.disabled).toBe(true);
+  });
+
+  it("dot click jumps to specific scene", () => {
+    renderWithProviders(() => <AttackStoryView story={SAMPLE_STORY} />);
+    const dots = screen.getAllByRole("tab");
+    expect(dots.length).toBe(3);
+    fireEvent.click(dots[2]);
+    expect(screen.getByText("シーン 3")).toBeTruthy();
+  });
+
+  it("toggles autoplay button label between start/pause", () => {
+    renderWithProviders(() => <AttackStoryView story={SAMPLE_STORY} />);
+    const toggle = screen.getByLabelText("自動再生を開始");
+    fireEvent.click(toggle);
+    expect(screen.getByLabelText("自動再生を停止")).toBeTruthy();
+  });
+
+  it("region has correct role and aria-label", () => {
+    renderWithProviders(() => <AttackStoryView story={SAMPLE_STORY} />);
+    const region = screen.getByRole("region");
+    expect(region.getAttribute("aria-label")).toBe("攻撃ストーリーボード");
+  });
+
+  it("ArrowRight key advances scene", () => {
+    renderWithProviders(() => <AttackStoryView story={SAMPLE_STORY} />);
+    const region = screen.getByRole("region");
+    fireEvent.keyDown(region, { key: "ArrowRight" });
+    expect(screen.getByText("シーン 2")).toBeTruthy();
+  });
+
+  it("End key jumps to the last scene", () => {
+    renderWithProviders(() => <AttackStoryView story={SAMPLE_STORY} />);
+    const region = screen.getByRole("region");
+    fireEvent.keyDown(region, { key: "End" });
+    expect(screen.getByText("シーン 3")).toBeTruthy();
+  });
+
+  it("Home key returns to first scene", () => {
+    renderWithProviders(() => <AttackStoryView story={SAMPLE_STORY} />);
+    const region = screen.getByRole("region");
+    fireEvent.keyDown(region, { key: "End" });
+    fireEvent.keyDown(region, { key: "Home" });
+    expect(screen.getByText("シーン 1")).toBeTruthy();
+  });
+
+  it("renders position indicator", () => {
+    renderWithProviders(() => <AttackStoryView story={SAMPLE_STORY} />);
+    expect(screen.getByText("シーン 1 / 3")).toBeTruthy();
+  });
+});

--- a/src/utils/__tests__/story-resolver.test.ts
+++ b/src/utils/__tests__/story-resolver.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { resolveRawRef } from "../story-resolver";
+import type { RawExchange } from "../../../shared/api-types";
+
+function makeExchange(): RawExchange {
+  return {
+    browserToOrchestrator: {
+      request: {
+        line: "POST /api/orchestrator/exec HTTP/1.1",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: '{"scenarioId":"test"}',
+        bytesSent: 80,
+      },
+      response: {
+        line: "HTTP/1.1 200 OK",
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: '{"ok":true}',
+        bytesReceived: 12,
+      },
+    },
+    orchestratorToVictim: {
+      request: {
+        line: "POST /totp/login-replay HTTP/1.1",
+        headers: { Host: "victim-web:4001", "Content-Type": "application/json" },
+        body: '{"username":"seed_alice"}',
+        bytesSent: 100,
+      },
+      response: {
+        line: "HTTP/1.1 200 OK",
+        status: 200,
+        headers: { "content-type": "application/json", "x-computed-otp": "123456" },
+        body: '{"ok":true,"computedOtp":"123456"}',
+        bytesReceived: 120,
+      },
+      targetResolvedTo: "http://localhost:4001",
+    },
+    elapsedMs: 42,
+  };
+}
+
+describe("resolveRawRef", () => {
+  it("returns undefined when exchange is null/undefined", () => {
+    expect(
+      resolveRawRef(
+        { pair: "orchestratorToVictim", side: "request", field: "line" },
+        null,
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveRawRef(
+        { pair: "orchestratorToVictim", side: "request", field: "line" },
+        undefined,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("resolves request line", () => {
+    const ex = makeExchange();
+    expect(
+      resolveRawRef(
+        { pair: "orchestratorToVictim", side: "request", field: "line" },
+        ex,
+      ),
+    ).toBe("POST /totp/login-replay HTTP/1.1");
+  });
+
+  it("resolves response body", () => {
+    const ex = makeExchange();
+    expect(
+      resolveRawRef(
+        { pair: "orchestratorToVictim", side: "response", field: "body" },
+        ex,
+      ),
+    ).toBe('{"ok":true,"computedOtp":"123456"}');
+  });
+
+  it("resolves header case-insensitively (HTTP spec)", () => {
+    const ex = makeExchange();
+    // Header set as "Host" (PascalCase). Lookup with lowercase, uppercase, mixed.
+    expect(
+      resolveRawRef(
+        { pair: "orchestratorToVictim", side: "request", field: { header: "host" } },
+        ex,
+      ),
+    ).toBe("victim-web:4001");
+    expect(
+      resolveRawRef(
+        { pair: "orchestratorToVictim", side: "request", field: { header: "HOST" } },
+        ex,
+      ),
+    ).toBe("victim-web:4001");
+    expect(
+      resolveRawRef(
+        { pair: "orchestratorToVictim", side: "response", field: { header: "X-Computed-OTP" } },
+        ex,
+      ),
+    ).toBe("123456");
+  });
+
+  it("returns undefined when header not present", () => {
+    const ex = makeExchange();
+    expect(
+      resolveRawRef(
+        { pair: "orchestratorToVictim", side: "request", field: { header: "Cookie" } },
+        ex,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("handles body=null gracefully", () => {
+    const ex = makeExchange();
+    ex.orchestratorToVictim.response.body = null;
+    expect(
+      resolveRawRef(
+        { pair: "orchestratorToVictim", side: "response", field: "body" },
+        ex,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("respects pair selection", () => {
+    const ex = makeExchange();
+    expect(
+      resolveRawRef(
+        { pair: "browserToOrchestrator", side: "request", field: "line" },
+        ex,
+      ),
+    ).toBe("POST /api/orchestrator/exec HTTP/1.1");
+    expect(
+      resolveRawRef(
+        { pair: "browserToOrchestrator", side: "response", field: "body" },
+        ex,
+      ),
+    ).toBe('{"ok":true}');
+  });
+});

--- a/src/utils/story-resolver.ts
+++ b/src/utils/story-resolver.ts
@@ -1,0 +1,36 @@
+/**
+ * AttackStoryboard (DESIGN/35 §7) — RawExchangeRef 解決ヘルパー。
+ *
+ * 設計判断: scenario データは静的 (*-scenarios.ts) なのでシリアライズ可能な
+ * 構造体参照を採用。resolver 関数や JSON pointer は不採用 (DESIGN/35 §7.1)。
+ *
+ * - header lookup は case-insensitive (HTTP 仕様準拠)
+ * - 解決失敗 (rawExchange null / pair 不在 / header 不在) は undefined を返す
+ * - 警告ログは出さない (シナリオ作者の意図的選択もある)
+ */
+import type { RawExchange, RawExchangeRef } from "../../shared/api-types";
+
+export function resolveRawRef(
+  ref: RawExchangeRef,
+  exchange: RawExchange | null | undefined,
+): string | undefined {
+  if (!exchange) return undefined;
+  const pair = exchange[ref.pair];
+  if (!pair) return undefined;
+  const sideObj = pair[ref.side] as
+    | { line: string; headers: Record<string, string>; body: string | null }
+    | undefined;
+  if (!sideObj) return undefined;
+
+  if (ref.field === "line") return sideObj.line;
+  if (ref.field === "body") return sideObj.body ?? undefined;
+
+  if (typeof ref.field === "object" && "header" in ref.field) {
+    const target = ref.field.header.toLowerCase();
+    for (const [k, v] of Object.entries(sideObj.headers)) {
+      if (k.toLowerCase() === target) return v;
+    }
+    return undefined;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

- **mfa-otp-replay (CWE-294) live 化** — Phase 2 PoC 第 5 号 = Phase 2 完結。victim-web に `POST /totp/login-replay` を追加し、現在時刻 OTP の 2 連続検証で `leakedToAttacker` (email/balance/apiKey 等) を 1 リクエストで漏えいさせる
- **AttackStoryboard UI 基盤導入 (DESIGN/35)** — 全 38 攻撃シナリオに波及する紙芝居型可視化基盤。キャラ + 吹き出し + ◄ ► + dot indicator + auto-play で攻撃の物語進行を学習者に見せる
- **mfa-otp-replay に 7 シーン story 執筆** — setup → recon → victim-login → replay → server-fails → leak → defense

## Why this PR is bigger than PR-1〜3 (~3,600 行)

ユーザー指摘「攻撃側が何を取れてしまうのかわかりずらい」に応えて、Phase 2 完結 PR で全シナリオ波及型の UI 基盤も同時投入。Phase 3 (A 群残り 13 件) では本基盤に乗ってシーンスクリプトのみ書けば紙芝居化できる構造。

## DESIGN ⇄ 実装対応

| DESIGN | 実装 |
|---|---|
| DESIGN/35 §2 (型) | `shared/api-types.ts` (AttackStoryScene/Visual/Actor/RawExchangeRef/HttpHighlight) |
| DESIGN/35 §3 (UI) | `AttackStoryView.tsx` + `AttackStoryScene.tsx` + `AttackStoryControls.tsx` + `StoryActorAvatar.tsx` (各 CSS) |
| DESIGN/35 §4 (統合) | `AttackPanel.tsx` (`hasStory()` メモ + classic timeline 折りたたみ共存) |
| DESIGN/35 §7 (raw exchange リンク) | `src/utils/story-resolver.ts` (case-insensitive header lookup) |
| DESIGN/32 §4.7 (TOTP 脆弱) | `services/victim-web/src/routes/totp-vuln.ts` + `utils/totp.ts` |
| DESIGN/30 §5.3 (Phase 2 PoC #5) | `mfa-scenarios.ts` の `mfa-otp-replay` mode/liveTemplate/story + `MfaFlow.tsx` 配線 |
| DESIGN/33 §1.3 | AttackStoryView 共存方針を表に追記 |

## Test plan

- [x] `npm run test:ci` — 全 541 tests pass (退行なし、新規 36 tests を含む)
- [x] `npx tsc --noEmit` — TypeScript エラーなし
- [x] `npm run build` — production build 成功
- [x] preview server (`npm run dev:no-docker`) → 認証・認可 → MFA/TOTP → 攻撃者モード → mfa-otp-replay
  - [x] LIVE バッジ表示
  - [x] RawHttpComposer (POST /totp/login-replay, body: `{"username":"seed_alice"}`) 編集可能
  - [x] SEND 押下 → orchestrator/exec → victim-web → 200 + `leakedToAttacker` 含む JSON
  - [x] AttackStoryView 表示、シーン 1/7 から開始
  - [x] ► / ◄ / dot ジャンプ動作
  - [x] シーン 4 で http-request visual に `Content-Type` highlight 表示
  - [x] シーン 6 で data-leak visual (severity=critical) に `leakedToAttacker` JSON 表示
  - [x] シーン 7 で code-defense visual に `server/routes/mfa-totp.ts step2` の防御コード + 6 行ハイライト表示
  - [x] コンソールエラーなし

## Phase 2 完結

| # | シナリオ | PR |
|---|---|---|
| 1 | jwt-alg-none | #14 |
| 2 | oauth-state-csrf | #17 |
| 3 | rbac-idor | #18 |
| 4 | session-fixation | #19 |
| 5 | mfa-otp-replay | **本 PR** |

次セッションで Phase 3 (A 群残り 13 件) 着手予定。既存 4 件への storyboard 波及 (jwt-alg-none / oauth-state-csrf / rbac-idor / session-fixation) は別 PR で実施 (DESIGN/35 §10.2 案 C: 2 件ずつ 2 PR)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)