### PR TITLE
feat: AttackStoryboard 波及 PR-A — jwt-alg-none / oauth-state-csrf に story + leakedToAttacker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,8 @@ PR レビュー時の「仕様 ↔ 実装」往復に使う。Phase 2+ で新規
 | DESIGN/35 §4 (AttackPanel 統合) | `src/components/shared/AttackPanel.tsx` (`hasStory()` メモ + AttackStoryView 表示 + `<details>` 折りたたみの classic timeline) + `AttackPanel.css` (`.attack-classic-timeline-fold`) | 共存方式 (story 持ちは新 UI、未対応は従来 timeline 展開) |
 | DESIGN/35 §7 (raw exchange リンク方式) | `src/utils/story-resolver.ts` (`resolveRawRef` case-insensitive header lookup) + `src/utils/__tests__/story-resolver.test.ts` | 構造体参照ヘルパー |
 | DESIGN/35 §11.2-§11.6 (テスト要件) | `src/components/shared/__tests__/AttackStoryView.test.tsx` (11 cases) + `AttackStoryScene.test.tsx` (8 cases) + `src/utils/__tests__/story-resolver.test.ts` (7 cases) | UI navigation / variant 描画 / a11y / resolver helper |
+| DESIGN/35 §10.2 (PR-A 波及 — jwt-alg-none) | `src/components/auth/attacks/scenarios/jwt-scenarios.ts` (`jwt-alg-none.story` 7 シーン + `storyDefaultDurationMs`) + `services/victim-web/src/routes/jwt-vuln.ts` (`leakedToAttacker` + X-Token-Alg / X-Forged-Sub / X-Forged-Role ヘッダ + SEED_USER_PROFILES) + `services/victim-web/__tests__/jwt-vuln.test.ts` (6 tests) | 既存 PoC への storyboard + leakedToAttacker 波及 (auth プロトコル系 1/2) |
+| DESIGN/35 §10.2 (PR-A 波及 — oauth-state-csrf) | `src/components/auth/attacks/scenarios/oauth-scenarios.ts` (`oauth-state-csrf.story` 7 シーン + `storyDefaultDurationMs`) + `services/victim-web/src/routes/oauth-vuln.ts` (`leakedToAttacker` + X-Authorization-Code / X-Csrf-Risk / X-State-Validated ヘッダ + VICTIM_PROFILE_AT_RISK) + `services/victim-web/__tests__/oauth-vuln.test.ts` (+2 tests = 6 tests) + `server/__tests__/scenarios/oauth-state-csrf.test.ts` (+1 test = 5 tests) | 既存 PoC への storyboard + leakedToAttacker 波及 (auth プロトコル系 2/2) |
 
 ## ロードマップ: 攻撃デモの live 化 (Phase 1-5, 約 11 週)
 

--- a/server/__tests__/scenarios/oauth-state-csrf.test.ts
+++ b/server/__tests__/scenarios/oauth-state-csrf.test.ts
@@ -186,6 +186,60 @@ describe("Phase 2 PoC: oauth-state-csrf (orchestrator → victim-web)", () => {
     expect(steps[2].id).toBe("oauth-state-csrf-verify");
   });
 
+  it("victim 応答ボディに leakedToAttacker (token exchange 後の予定 profile) が含まれる", async () => {
+    const app = createOrchestratorApp();
+    const res = await app.request("/api/orchestrator/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scenarioId: "oauth-state-csrf",
+        target: "victim-web",
+        request: {
+          method: "GET",
+          path: "/oauth/authorize?client_id=demo-app&redirect_uri=http%3A%2F%2Fattacker.example%2Fcb",
+          headers: { Accept: "application/json" },
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: {
+        rawExchange: {
+          orchestratorToVictim: {
+            response: { body: string | null; headers: Record<string, string> };
+          };
+        };
+      };
+    };
+    const ex = json.data.rawExchange.orchestratorToVictim;
+    const victimBody = JSON.parse(ex.response.body ?? "{}") as {
+      code: string;
+      leakedToAttacker: {
+        username: string;
+        email: string;
+        futureAccessToken: string;
+        authorizationCode: string;
+        stateValidated: boolean;
+        attackerControlledRedirect: string;
+      };
+    };
+    expect(victimBody.leakedToAttacker.username).toBe("seed_alice");
+    expect(victimBody.leakedToAttacker.email).toBe("alice@victim.local");
+    expect(victimBody.leakedToAttacker.futureAccessToken).toMatch(
+      /^VICTIM_AT_REDACTED_/,
+    );
+    expect(victimBody.leakedToAttacker.authorizationCode).toBe(victimBody.code);
+    expect(victimBody.leakedToAttacker.stateValidated).toBe(false);
+    expect(victimBody.leakedToAttacker.attackerControlledRedirect).toBe(
+      "http://attacker.example/cb",
+    );
+
+    // 教材ヒントヘッダが victim → orchestrator 経路を抜けて raw exchange に保存される
+    const headerKeys = Object.keys(ex.response.headers).map((k) => k.toLowerCase());
+    expect(headerKeys).toContain("x-authorization-code");
+    expect(headerKeys).toContain("x-csrf-risk");
+  });
+
   it("client_id / redirect_uri 欠如時は victim が 400 を返し outcome は blocked", async () => {
     const app = createOrchestratorApp();
     const res = await app.request("/api/orchestrator/exec", {

--- a/services/victim-web/__tests__/jwt-vuln.test.ts
+++ b/services/victim-web/__tests__/jwt-vuln.test.ts
@@ -1,0 +1,145 @@
+/**
+ * victim-web 単体テスト: POST /jwt/verify (jwt-alg-none 脆弱エンドポイント)
+ *
+ * orchestrator を介さずに victim-web 単体の脆弱性が成立することを直接確認する。
+ * orchestrator 経由の e2e は server/__tests__/orchestrator-live.test.ts でカバーされている。
+ *
+ * DESIGN/32 §4.1 / §8.1 (必須テスト): "POST /jwt/verify — alg=none で 200 が返ること"
+ * DESIGN/35 PR-A 波及: leakedToAttacker フィールドの存在を検証
+ */
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import jwt from "jsonwebtoken";
+import { jwtVulnRoutes } from "../src/routes/jwt-vuln.js";
+
+function createApp() {
+  const app = new Hono();
+  app.route("/jwt", jwtVulnRoutes);
+  return app;
+}
+
+/** alg=none + 空署名で claims を載せた偽造 JWT を作る */
+function buildAlgNoneToken(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.`;
+}
+
+describe("victim-web: POST /jwt/verify (CWE-345 jwt-alg-none)", () => {
+  it("alg=none + 空署名トークンで 200 + valid: true を返す (脆弱性の核心)", async () => {
+    const app = createApp();
+    const token = buildAlgNoneToken({ sub: "seed_alice", role: "admin" });
+    const res = await app.request("/jwt/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      valid: boolean;
+      algorithm: string;
+      claims: { sub: string; role: string };
+      note?: string;
+    };
+    expect(json.valid).toBe(true);
+    expect(json.algorithm).toBe("none");
+    expect(json.claims.sub).toBe("seed_alice");
+    expect(json.claims.role).toBe("admin");
+    expect(json.note).toContain("alg=none accepted");
+  });
+
+  it("alg=none 経路で seed user の leakedToAttacker プロファイルが返る (storyboard data-leak 用)", async () => {
+    const app = createApp();
+    const token = buildAlgNoneToken({ sub: "seed_alice", role: "admin" });
+    const res = await app.request("/jwt/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      leakedToAttacker: {
+        userId: number;
+        username: string;
+        role: string;
+        email: string;
+        demoApiKey: string;
+        demoBalance: string;
+      } | null;
+    };
+    expect(json.leakedToAttacker).not.toBeNull();
+    expect(json.leakedToAttacker!.username).toBe("seed_alice");
+    expect(json.leakedToAttacker!.email).toBe("alice@victim.local");
+    expect(json.leakedToAttacker!.demoApiKey).toMatch(/^sk_demo_alice_REDACTED_/);
+    expect(json.leakedToAttacker!.demoBalance).toMatch(/^\$/);
+    // 教材ヒントヘッダ
+    expect(res.headers.get("X-Token-Alg")).toBe("none");
+    expect(res.headers.get("X-Forged-Sub")).toBe("seed_alice");
+    expect(res.headers.get("X-Forged-Role")).toBe("admin");
+  });
+
+  it("未知の sub の場合 leakedToAttacker は null になる (claims は通っても profile 不在)", async () => {
+    const app = createApp();
+    const token = buildAlgNoneToken({ sub: "ghost_user", role: "admin" });
+    const res = await app.request("/jwt/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      valid: boolean;
+      leakedToAttacker: unknown;
+    };
+    expect(json.valid).toBe(true);
+    expect(json.leakedToAttacker).toBeNull();
+  });
+
+  it("HS256 + WEAK_SECRET 経由でも seed user の leakedToAttacker が返る", async () => {
+    const app = createApp();
+    const token = jwt.sign({ sub: "seed_admin", role: "admin" }, "secret", { algorithm: "HS256" });
+    const res = await app.request("/jwt/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      valid: boolean;
+      algorithm: string;
+      leakedToAttacker: { username: string; role: string } | null;
+    };
+    expect(json.valid).toBe(true);
+    expect(json.algorithm).toBe("HS256");
+    expect(json.leakedToAttacker).not.toBeNull();
+    expect(json.leakedToAttacker!.username).toBe("seed_admin");
+    expect(json.leakedToAttacker!.role).toBe("admin");
+    expect(res.headers.get("X-Token-Alg")).toBe("HS256");
+  });
+
+  it("token フィールド欠如時は 400 を返す (最小バリデーション)", async () => {
+    const app = createApp();
+    const res = await app.request("/jwt/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { valid: boolean; error: string };
+    expect(json.valid).toBe(false);
+    expect(json.error).toContain("token");
+  });
+
+  it("Invalid JSON body で 400 を返す", async () => {
+    const app = createApp();
+    const res = await app.request("/jwt/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { valid: boolean; error: string };
+    expect(json.valid).toBe(false);
+    expect(json.error).toBe("Invalid JSON body");
+  });
+});

--- a/services/victim-web/__tests__/oauth-vuln.test.ts
+++ b/services/victim-web/__tests__/oauth-vuln.test.ts
@@ -82,4 +82,49 @@ describe("victim-web: GET /oauth/authorize (CWE-352 oauth-state-csrf)", () => {
     expect(json.ok).toBe(false);
     expect(json.error).toContain("redirect_uri");
   });
+
+  it("成功レスポンスに leakedToAttacker (token exchange 後に奪取される profile) が含まれる", async () => {
+    const app = createApp();
+    const res = await app.request(
+      "/oauth/authorize?client_id=demo-app&redirect_uri=http%3A%2F%2Fattacker.example%2Fcb",
+      { method: "GET" },
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      code: string;
+      leakedToAttacker: {
+        userId: number;
+        username: string;
+        email: string;
+        scopesGranted: string[];
+        futureAccessToken: string;
+        authorizationCode: string;
+        stateValidated: boolean;
+        attackerControlledRedirect: string;
+      };
+    };
+    expect(json.leakedToAttacker.username).toBe("seed_alice");
+    expect(json.leakedToAttacker.email).toBe("alice@victim.local");
+    expect(json.leakedToAttacker.futureAccessToken).toMatch(/^VICTIM_AT_REDACTED_/);
+    expect(json.leakedToAttacker.scopesGranted).toContain("read");
+    // authorizationCode はレスポンス本体の code と一致
+    expect(json.leakedToAttacker.authorizationCode).toBe(json.code);
+    expect(json.leakedToAttacker.stateValidated).toBe(false);
+    expect(json.leakedToAttacker.attackerControlledRedirect).toBe(
+      "http://attacker.example/cb",
+    );
+  });
+
+  it("教材ヒントヘッダ X-Authorization-Code / X-Csrf-Risk / X-State-Validated を返す", async () => {
+    const app = createApp();
+    const res = await app.request(
+      "/oauth/authorize?client_id=demo-app&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback",
+      { method: "GET" },
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { code: string };
+    expect(res.headers.get("X-Authorization-Code")).toBe(json.code);
+    expect(res.headers.get("X-Csrf-Risk")).toBe("high");
+    expect(res.headers.get("X-State-Validated")).toBe("false");
+  });
 });

--- a/services/victim-web/src/routes/jwt-vuln.ts
+++ b/services/victim-web/src/routes/jwt-vuln.ts
@@ -7,13 +7,68 @@
  *
  * 対応 CWE: CWE-345 (alg=none), CWE-347 (signature stripping)
  * 堅牢実装: server/routes/jwt-ops.ts (algorithms allowlist 必須)
- * 関連設計書: DESIGN/04-safety-guardrails.md, DESIGN/32-victim-web-spec.md
+ * 関連設計書: DESIGN/04-safety-guardrails.md, DESIGN/32-victim-web-spec.md,
+ *             DESIGN/35-attack-storyboard.md (PR-A 波及で leakedToAttacker 追記)
  */
 import { Hono } from "hono";
 import jwt from "jsonwebtoken";
 
 // 教材用弱秘密鍵 — victim-web は orchestrator の HS256_SECRET と独立した固定値を持つ
 const WEAK_SECRET = "secret";
+
+/**
+ * 教材用シードユーザー + 漏えい想定データ。
+ * alg=none で受理した偽造 claims の sub に対応するプロファイルを「攻撃者が
+ * 認証バイパスで取得できるはずのデータ」として leakedToAttacker に詰める。
+ * 全フィールドが _DEMO_ / @victim.local / REDACTED マーカー入りで本物の
+ * secret は含まない (totp-vuln.ts と同パターン)。
+ */
+const SEED_USER_PROFILES: Readonly<
+  Record<
+    string,
+    Readonly<{
+      id: number;
+      username: string;
+      role: "user" | "admin";
+      email: string;
+      fullName: string;
+      lastLogin: string;
+      demoBalance: string;
+      demoApiKey: string;
+    }>
+  >
+> = {
+  seed_alice: {
+    id: 1,
+    username: "seed_alice",
+    role: "user",
+    email: "alice@victim.local",
+    fullName: "Alice Demo",
+    lastLogin: "2026-05-09T22:14:03Z",
+    demoBalance: "$12,345.67",
+    demoApiKey: "sk_demo_alice_REDACTED_aXX1",
+  },
+  seed_bob: {
+    id: 2,
+    username: "seed_bob",
+    role: "user",
+    email: "bob@victim.local",
+    fullName: "Bob Demo",
+    lastLogin: "2026-05-09T18:02:11Z",
+    demoBalance: "$987.65",
+    demoApiKey: "sk_demo_bob_REDACTED_bYY2",
+  },
+  seed_admin: {
+    id: 4,
+    username: "seed_admin",
+    role: "admin",
+    email: "admin@victim.local",
+    fullName: "Admin Demo",
+    lastLogin: "2026-05-10T07:55:42Z",
+    demoBalance: "$1,000,000.00",
+    demoApiKey: "sk_demo_admin_REDACTED_dZZ4",
+  },
+};
 
 export const jwtVulnRoutes = new Hono();
 
@@ -22,7 +77,9 @@ export const jwtVulnRoutes = new Hono();
  * alg=none トークンおよび任意のアルゴリズムが受理される (CWE-345)。
  *
  * 期待入力: { "token": "<JWT>" }
- * 期待挙動: 200 + { valid: true, claims: {...} } を返す (alg=none でも通過)
+ * 期待挙動: 200 + { valid: true, claims: {...}, algorithm, leakedToAttacker?: {...} } を返す
+ *           - 認証バイパスが成立した場合、claims.sub に対応する seed プロファイルを
+ *             leakedToAttacker に詰めて「攻撃者がこの偽造 token で奪取できる範囲」を可視化
  */
 jwtVulnRoutes.post("/verify", async (c) => {
   let body: { token?: unknown };
@@ -47,12 +104,33 @@ jwtVulnRoutes.post("/verify", async (c) => {
       if (header.alg === "none" && segments[2] === "") {
         // 署名検証を完全にスキップ — これが alg=none 脆弱性の本質
         const payloadJson = Buffer.from(segments[1], "base64url").toString("utf8");
-        const claims = JSON.parse(payloadJson);
+        const claims = JSON.parse(payloadJson) as Record<string, unknown>;
+        const sub = typeof claims.sub === "string" ? claims.sub : null;
+        const role = typeof claims.role === "string" ? claims.role : null;
+        const profile = sub !== null ? SEED_USER_PROFILES[sub] ?? null : null;
+
+        // 教材ヒント用ヘッダ (storyboard の data-leak visual で参照しやすい)
+        c.header("X-Token-Alg", "none");
+        if (sub !== null) c.header("X-Forged-Sub", sub);
+        if (role !== null) c.header("X-Forged-Role", role);
+
         return c.json({
           valid: true,
           claims,
           algorithm: "none",
           note: "signature verification skipped (vulnerable: alg=none accepted)",
+          leakedToAttacker: profile === null
+            ? null
+            : {
+                userId: profile.id,
+                username: profile.username,
+                role: profile.role,
+                email: profile.email,
+                fullName: profile.fullName,
+                lastLogin: profile.lastLogin,
+                demoBalance: profile.demoBalance,
+                demoApiKey: profile.demoApiKey,
+              },
         });
       }
     } catch {
@@ -62,8 +140,33 @@ jwtVulnRoutes.post("/verify", async (c) => {
 
   // alg=none 以外は弱秘密鍵で HMAC 検証 (algorithms オプション未指定 = 脆弱)
   try {
-    const decoded = jwt.verify(token, WEAK_SECRET);
-    return c.json({ valid: true, claims: decoded, algorithm: "HS256" });
+    const decoded = jwt.verify(token, WEAK_SECRET) as Record<string, unknown> | string;
+    const claims = typeof decoded === "string" ? null : decoded;
+    const sub = claims !== null && typeof claims.sub === "string" ? claims.sub : null;
+    const role = claims !== null && typeof claims.role === "string" ? claims.role : null;
+    const profile = sub !== null ? SEED_USER_PROFILES[sub] ?? null : null;
+
+    c.header("X-Token-Alg", "HS256");
+    if (sub !== null) c.header("X-Forged-Sub", sub);
+    if (role !== null) c.header("X-Forged-Role", role);
+
+    return c.json({
+      valid: true,
+      claims: decoded,
+      algorithm: "HS256",
+      leakedToAttacker: profile === null
+        ? null
+        : {
+            userId: profile.id,
+            username: profile.username,
+            role: profile.role,
+            email: profile.email,
+            fullName: profile.fullName,
+            lastLogin: profile.lastLogin,
+            demoBalance: profile.demoBalance,
+            demoApiKey: profile.demoApiKey,
+          },
+    });
   } catch (err) {
     return c.json(
       {

--- a/services/victim-web/src/routes/oauth-vuln.ts
+++ b/services/victim-web/src/routes/oauth-vuln.ts
@@ -11,11 +11,31 @@
  *
  * 対応 CWE: CWE-352 (state CSRF)
  * 堅牢実装: server/routes/oauth-sim.ts (state 必須検証)
- * 関連設計書: DESIGN/04-safety-guardrails.md, DESIGN/32-victim-web-spec.md §4.4
+ * 関連設計書: DESIGN/04-safety-guardrails.md, DESIGN/32-victim-web-spec.md §4.4,
+ *             DESIGN/35-attack-storyboard.md (PR-A 波及で leakedToAttacker 追記)
  */
 import { Hono } from "hono";
 
 export const oauthVulnRoutes = new Hono();
+
+/**
+ * 教材用「攻撃者がこのコードで奪取する予定の victim プロファイル」。
+ * state なしで authorize された code を attacker が握れば、後段の
+ * /oauth/token 交換で access_token と紐付くこのデータ一式が手に入る。
+ * authorize 段階のレスポンス自体には profile は含まれないが、storyboard で
+ * 「攻撃成立後に何が漏えいするか」を可視化するため、教材的に同一レスポンスへ
+ * leakedToAttacker として埋め込む (totp-vuln.ts / jwt-vuln.ts と同パターン)。
+ */
+const VICTIM_PROFILE_AT_RISK = {
+  userId: 1,
+  username: "seed_alice",
+  email: "alice@victim.local",
+  fullName: "Alice Demo",
+  scopesGranted: ["read", "profile"],
+  // この code を attacker が token endpoint に渡した結果として
+  // 払い出される予定の access_token (教材スタブ — 実トークンは含まない)
+  futureAccessToken: "VICTIM_AT_REDACTED_alice_seed_8a9c",
+} as const;
 
 /**
  * 脆弱: state パラメータを一切検証せず認可コードを発行する。
@@ -23,8 +43,8 @@ export const oauthVulnRoutes = new Hono();
  *
  * 期待入力: GET /oauth/authorize?client_id=<id>&redirect_uri=<uri>[&scope=<scope>][&state=<state>]
  * 期待挙動:
- *   - state なし → 200 + 認可コード発行 (脆弱性の核心)
- *   - state あり → 200 + 認可コード発行 (検証も無効化されているため state は単に echo)
+ *   - state なし → 200 + 認可コード発行 + leakedToAttacker (脆弱性の核心)
+ *   - state あり → 200 + 認可コード発行 + leakedToAttacker (検証も無効化されているため state は単に echo)
  *   - client_id / redirect_uri 欠如 → 400
  *
  * 堅牢実装 (server/routes/oauth-sim.ts) では state パラメータが必須であり、
@@ -55,6 +75,11 @@ oauthVulnRoutes.get("/authorize", (c) => {
     .toString(36)
     .slice(2, 10)}`;
 
+  // 教材ヒント用ヘッダ (storyboard の data-leak visual で参照しやすい)
+  c.header("X-Authorization-Code", code);
+  c.header("X-Csrf-Risk", "high");
+  c.header("X-State-Validated", "false");
+
   return c.json({
     ok: true,
     code,
@@ -64,5 +89,12 @@ oauthVulnRoutes.get("/authorize", (c) => {
     response_type: responseType,
     state_received: state, // null でも 200 を返す = 脆弱性
     note: "authorization code issued without verifying state (CWE-352 vulnerable: state parameter not enforced)",
+    leakedToAttacker: {
+      ...VICTIM_PROFILE_AT_RISK,
+      scopesGranted: [...VICTIM_PROFILE_AT_RISK.scopesGranted],
+      authorizationCode: code,
+      stateValidated: false,
+      attackerControlledRedirect: redirectUri,
+    },
   });
 });

--- a/src/components/auth/attacks/scenarios/jwt-scenarios.ts
+++ b/src/components/auth/attacks/scenarios/jwt-scenarios.ts
@@ -66,6 +66,154 @@ const decoded = jwt.verify(token, secret);  // 危険`,
       // header: {"alg":"none","typ":"JWT"}, payload: {"sub":"seed_alice","role":"admin"}
       body: '{\n  "token": "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJzZWVkX2FsaWNlIiwicm9sZSI6ImFkbWluIn0."\n}',
     },
+    // PR-A 波及: AttackStoryboard (DESIGN/35) 7 シーン story。
+    // alg=none で偽造した admin token がそのまま受理され、leakedToAttacker
+    // (alice の email / 残高 / API キー等) が一括で奪取される物語を可視化する。
+    storyDefaultDurationMs: 4000,
+    story: [
+      {
+        id: "scene-1-setup",
+        title: "Target: alice's admin endpoint",
+        titleJa: "標的: alice の管理エンドポイント",
+        actor: "attacker",
+        speech: {
+          ja: "alice の管理権限を奪う。HS256 の鍵は持っていないが、検証側を騙せばいい。",
+          en: "I want alice's admin role. I don't have the HS256 key — but I can fool the verifier.",
+        },
+        narration: {
+          ja: "攻撃者は被害者 alice の管理者権限を狙っています。alice の本物の JWT を入手していなくても、サーバの JWT 検証実装に漏れがあれば偽造が成立します。",
+          en: "The attacker wants alice's admin role. Even without her real JWT, a sloppy verifier on the server can be tricked into accepting a forgery.",
+        },
+        highlightActors: ["victim"],
+      },
+      {
+        id: "scene-2-recon",
+        title: "Inspect the JWT structure",
+        titleJa: "JWT の構造を観察",
+        actor: "attacker",
+        speech: {
+          ja: "JWT は header.payload.signature の 3 部構成。header の alg を書き換えればどうなる?",
+          en: "JWTs are header.payload.signature. What if I just rewrite alg in the header?",
+        },
+        narration: {
+          ja: "RFC 7518 §3.6 は alg=\"none\" を許容しています。algorithms 許可リストを渡さない jwt.verify() は、その「妥協」を本番環境で再現してしまうことがあります (CWE-345)。",
+          en: "RFC 7518 §3.6 permits alg=\"none\". A jwt.verify() call without an algorithms allowlist can reproduce that compromise in production (CWE-345).",
+        },
+        visual: {
+          type: "ascii",
+          content:
+            "JWT layout:\n" +
+            "  ┌─────────────┐.┌─────────────┐.┌─────────────┐\n" +
+            "  │   HEADER    │ │   PAYLOAD   │ │  SIGNATURE  │\n" +
+            "  │ alg, typ    │ │ sub, role…  │ │ HMAC bytes  │\n" +
+            "  └─────────────┘ └─────────────┘ └─────────────┘\n" +
+            "                          ↑\n" +
+            "                attacker rewrites alg → \"none\"",
+        },
+      },
+      {
+        id: "scene-3-forge",
+        title: "Forge alg=none + admin claims",
+        titleJa: "alg=none + admin claims を偽造",
+        actor: "attacker",
+        speech: {
+          ja: "header={alg:'none'}, payload={sub:'seed_alice', role:'admin'}, signature は空文字。",
+          en: "header={alg:'none'}, payload={sub:'seed_alice', role:'admin'}, signature stays empty.",
+        },
+        narration: {
+          ja: "偽造 JWT は base64url でエンコードしたヘッダ・ペイロードをドットで連結し、3 番目のセグメント (署名) を空文字列にするだけで完成します。秘密鍵は不要です。",
+          en: "The forgery is just base64url(header) . base64url(payload) . — three segments where the signature slot is empty. No secret needed.",
+        },
+        highlightActors: ["attacker"],
+      },
+      {
+        id: "scene-4-send",
+        title: "Send the forged token",
+        titleJa: "偽造トークンを送信",
+        actor: "attacker",
+        speech: {
+          ja: "RawHttpComposer 経由で orchestrator → victim-web に届ける。Host は強制的に victim-web に上書きされる。",
+          en: "Push it through orchestrator → victim-web. Orchestrator forces the Host header so I can't redirect anywhere.",
+        },
+        narration: {
+          ja: "orchestrator は VICTIM_ALLOWLIST で target を検証し、Host ヘッダを強制上書きします。攻撃者のリクエストは内部の victim-net 内に閉じ込められます (DESIGN/34 §4)。",
+          en: "Orchestrator validates target via VICTIM_ALLOWLIST and forces the Host header. The attacker's request stays inside victim-net (DESIGN/34 §4).",
+        },
+        visual: {
+          type: "http-request",
+          sourceRef: { pair: "orchestratorToVictim", side: "request", field: "line" },
+          highlight: [
+            {
+              target: "header",
+              match: "Content-Type",
+              tooltipJa: "JSON ボディとして偽造 JWT を送信",
+              tooltip: "Forged JWT delivered as JSON body",
+            },
+          ],
+        },
+      },
+      {
+        id: "scene-5-server-fails",
+        title: "Verifier accepts the forgery",
+        titleJa: "検証器が偽造を受理",
+        actor: "victim-srv",
+        speech: {
+          ja: "alg=none か。algorithms は指定されていない。じゃあ署名チェックはスキップでいいな。",
+          en: "alg=none, and no algorithms allowlist. Fine — I'll skip the signature check.",
+        },
+        narration: {
+          ja: "victim-web は jwt.verify() に algorithms を渡していないため、alg=none を素通りで受理してしまいます。レスポンスヘッダ X-Forged-Role に攻撃者が指定した role がそのまま返るのが目印です。",
+          en: "victim-web calls jwt.verify() without an algorithms list, so alg=none flies through. The X-Forged-Role response header echoes the role the attacker chose.",
+        },
+        visual: {
+          type: "data-leak",
+          label: "Forged role accepted (X-Forged-Role)",
+          labelJa: "偽造 role を受理 (X-Forged-Role)",
+          valueRef: {
+            pair: "orchestratorToVictim",
+            side: "response",
+            field: { header: "X-Forged-Role" },
+          },
+          severity: "high",
+        },
+      },
+      {
+        id: "scene-6-leak",
+        title: "Account data exfiltrated",
+        titleJa: "アカウントデータ漏えい",
+        actor: "attacker",
+        speech: {
+          ja: "alice として認証された。残高、API キー、メール…全部読める。",
+          en: "Authenticated as alice. Balance, API key, email — all readable.",
+        },
+        narration: {
+          ja: "victim-web のレスポンスボディには「攻撃者がこの偽造 token で奪取できる範囲」が leakedToAttacker フィールドに詰められています。本番ではこのまま管理 API を呼び放題になります。",
+          en: "The response body's leakedToAttacker field shows exactly what the forgery unlocks. In production this would be a free pass to admin APIs.",
+        },
+        visual: {
+          type: "data-leak",
+          label: "Response body (leakedToAttacker)",
+          labelJa: "レスポンスボディ (leakedToAttacker)",
+          valueRef: { pair: "orchestratorToVictim", side: "response", field: "body" },
+          severity: "critical",
+        },
+      },
+      {
+        id: "scene-7-defense",
+        title: "Defense: pin the algorithms allowlist",
+        titleJa: "防御: algorithms 許可リストを固定する",
+        actor: "narrator",
+        narration: {
+          ja: "堅牢実装は jwt.verify() に必ず algorithms: [\"HS256\"] のような許可リストを渡し、alg=none を含む想定外アルゴリズムを拒否します。RFC 7518 §3.6 と OWASP JWT Cheat Sheet が同等の対策を勧告しています。",
+          en: "A defended verifier always passes algorithms: [\"HS256\"] (or similar) to jwt.verify(), rejecting alg=none and any other unintended algorithm. RFC 7518 §3.6 and the OWASP JWT Cheat Sheet prescribe the same control.",
+        },
+        visual: {
+          type: "code-defense",
+          codeHintIndex: 0,
+          lineHighlight: [2, 4],
+        },
+      },
+    ],
   },
   {
     id: "jwt-weak-secret-bruteforce",

--- a/src/components/auth/attacks/scenarios/oauth-scenarios.ts
+++ b/src/components/auth/attacks/scenarios/oauth-scenarios.ts
@@ -82,6 +82,162 @@ const authUrl = \`/api/oauth/authorize?client_id=demo-app&redirect_uri=\${redire
       path: "/oauth/authorize?client_id=demo-app&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth%2Foauth%2Fcallback&scope=read&response_type=code",
       headers: { Accept: "application/json" },
     },
+    // PR-A 波及: AttackStoryboard (DESIGN/35) 7 シーン story。
+    // state 未検証で発行された認可コードを攻撃者が握り、後続の token exchange で
+    // alice の email / scope / future access token を奪取する流れを可視化する。
+    storyDefaultDurationMs: 4000,
+    story: [
+      {
+        id: "scene-1-setup",
+        title: "Target: alice's session at the OAuth client",
+        titleJa: "標的: OAuth クライアントの alice セッション",
+        actor: "attacker",
+        speech: {
+          ja: "alice の OAuth セッションに自分のコードを忍び込ませて、彼女のリソースを乗っ取る。",
+          en: "I want my own code dropped into alice's OAuth session so I can pivot to her resources.",
+        },
+        narration: {
+          ja: "OAuth state パラメータは認可リクエストとコールバックを紐付ける CSRF 防御です (RFC 6749 §10.12)。クライアントが state を発行・検証しないと、攻撃者が任意の認可コードを被害者のコールバックに注入できます (CWE-352)。",
+          en: "OAuth's state parameter binds an authorize request to its callback (RFC 6749 §10.12). Without it, an attacker can inject an arbitrary authorization code into the victim's callback (CWE-352).",
+        },
+        highlightActors: ["victim"],
+      },
+      {
+        id: "scene-2-recon",
+        title: "Inspect the authorize URL",
+        titleJa: "authorize URL を観察",
+        actor: "attacker",
+        speech: {
+          ja: "クライアントの authorize URL に state パラメータが入っていない。チャンスだ。",
+          en: "The client's authorize URL has no state parameter. That's the opening.",
+        },
+        narration: {
+          ja: "攻撃者はクライアントが組み立てる URL を観察し、state が省略されていることを確認します。state があっても sessionStorage と照合していなければ同じく脆弱です (RFC 6749 §10.12)。",
+          en: "The attacker watches the client's outgoing URL and notices state is missing. Even if state were present, it would still be vulnerable when not matched against sessionStorage (RFC 6749 §10.12).",
+        },
+        visual: {
+          type: "ascii",
+          content:
+            "Authorize URL (vulnerable client):\n" +
+            "  /oauth/authorize\n" +
+            "    ?client_id=demo-app\n" +
+            "    &redirect_uri=…/callback\n" +
+            "    &scope=read\n" +
+            "                ↑\n" +
+            "       no state= → CSRF window open",
+        },
+      },
+      {
+        id: "scene-3-victim-act",
+        title: "Victim begins the OAuth login",
+        titleJa: "被害者が OAuth ログインを開始",
+        actor: "victim",
+        speech: {
+          ja: "ログインしよう。OAuth で許可するだけだ。",
+          en: "Logging in. Just one OAuth consent click.",
+        },
+        narration: {
+          ja: "被害者 alice はクライアントの「OAuth でログイン」ボタンをクリックし、authorize エンドポイントにリダイレクトされる流れを起動します。state がないため、攻撃者の事前リクエストがそのまま被害者のセッションに紛れ込みます。",
+          en: "alice clicks the client's 'Sign in with OAuth' button. With no state, the attacker's pre-fetched code can be slipped into her session.",
+        },
+        visual: {
+          type: "sequence-arrow",
+          from: "victim",
+          to: "victim-srv",
+          label: "GET /oauth/authorize (no state)",
+          labelJa: "GET /oauth/authorize (state なし)",
+          direction: "request",
+        },
+        highlightActors: ["victim-srv"],
+      },
+      {
+        id: "scene-4-exploit",
+        title: "Attacker pre-fetches an authorization code",
+        titleJa: "攻撃者が事前に認可コードを取得",
+        actor: "attacker",
+        speech: {
+          ja: "RawHttpComposer から state なしで /oauth/authorize を叩く。code がそのまま返ってくる。",
+          en: "Send /oauth/authorize from RawHttpComposer with no state. The code drops straight back.",
+        },
+        narration: {
+          ja: "orchestrator/exec 経由で state を持たない authorize リクエストを送ると、victim-web は何の検証もせず認可コードを発行します。攻撃者はこのコードを被害者の callback URL に流し込めば、被害者のセッションが攻撃者アカウントに紐付きます。",
+          en: "Sent through orchestrator/exec without a state, victim-web issues an authorization code with no checks. Smuggle that code into the victim's callback URL and her session gets bound to the attacker's account.",
+        },
+        visual: {
+          type: "http-request",
+          sourceRef: { pair: "orchestratorToVictim", side: "request", field: "line" },
+          highlight: [
+            {
+              target: "header",
+              match: "Accept",
+              tooltipJa: "JSON 応答を要求",
+              tooltip: "Requesting a JSON response",
+            },
+          ],
+        },
+      },
+      {
+        id: "scene-5-server-fails",
+        title: "Server issues a code without checking state",
+        titleJa: "サーバが state を検証せず code を発行",
+        actor: "victim-srv",
+        speech: {
+          ja: "client_id と redirect_uri はある。state? まあ任意だし、code を発行してしまおう。",
+          en: "client_id and redirect_uri look fine. state? It's optional anyway — here's a fresh code.",
+        },
+        narration: {
+          ja: "victim-web は state パラメータを完全に無視して認可コードを発行します。レスポンスヘッダ X-Csrf-Risk: high と X-State-Validated: false が「これは検証なしで発行された code」であることをマークしています。",
+          en: "victim-web ignores state entirely and issues a code. The response headers X-Csrf-Risk: high and X-State-Validated: false flag the code as having been issued without validation.",
+        },
+        visual: {
+          type: "data-leak",
+          label: "CSRF risk header (X-Csrf-Risk)",
+          labelJa: "CSRF リスクヘッダ (X-Csrf-Risk)",
+          valueRef: {
+            pair: "orchestratorToVictim",
+            side: "response",
+            field: { header: "X-Csrf-Risk" },
+          },
+          severity: "high",
+        },
+      },
+      {
+        id: "scene-6-leak",
+        title: "Token exchange will hand alice's data over",
+        titleJa: "後続の token 交換で alice のデータが奪われる",
+        actor: "attacker",
+        speech: {
+          ja: "code を持ったから、次の /oauth/token でアクセストークンと alice のプロファイルが手に入る。",
+          en: "I have the code. The next /oauth/token call will hand me alice's access token and profile.",
+        },
+        narration: {
+          ja: "victim-web は教材のため leakedToAttacker フィールドに「この code を token endpoint に渡せば取れる予定の alice profile + futureAccessToken」を一括で入れて返します。本番環境ではここから別 API コールで段階的に漏えいします。",
+          en: "For teaching purposes victim-web bundles 'what the next /oauth/token call would unlock' (alice's profile + futureAccessToken) into leakedToAttacker. In production it would leak step by step.",
+        },
+        visual: {
+          type: "data-leak",
+          label: "Response body (leakedToAttacker)",
+          labelJa: "レスポンスボディ (leakedToAttacker)",
+          valueRef: { pair: "orchestratorToVictim", side: "response", field: "body" },
+          severity: "critical",
+        },
+      },
+      {
+        id: "scene-7-defense",
+        title: "Defense: bind state to the session and verify on callback",
+        titleJa: "防御: state をセッションに結び付けてコールバックで照合する",
+        actor: "narrator",
+        narration: {
+          ja: "堅牢実装は authorize リクエスト前に暗号学的乱数 state を生成して sessionStorage に保存し、コールバック受信時に厳密に照合します (RFC 6749 §10.12 / OWASP CSRF Cheat Sheet)。",
+          en: "A defended client generates a cryptographically random state, stores it in sessionStorage before the authorize request, and matches it strictly on callback (RFC 6749 §10.12 / OWASP CSRF Cheat Sheet).",
+        },
+        visual: {
+          type: "code-defense",
+          codeHintIndex: 0,
+          lineHighlight: [2, 9],
+        },
+      },
+    ],
   },
   {
     id: "oauth-redirect-uri-bypass",


### PR DESCRIPTION
## 概要 / Summary

DESIGN/35 §10.2 案 C の波及 **PR-A (auth プロトコル系 2 件)**。Phase 2 PR-4 ([#20](https://github.com/nok0321/osi-reference/pull/20)) で `mfa-otp-replay` に導入した 7 シーン storyboard + `leakedToAttacker` パターンを既存 PoC のうち **`jwt-alg-none` / `oauth-state-csrf`** に展開する。残り 2 件 (`rbac-idor` / `session-fixation` = アプリ系) は次 PR-B に残す。

## 関連 Issue / Linked issues

- refs [#20](https://github.com/nok0321/osi-reference/pull/20) (Phase 2 PR-4: AttackStoryboard 基盤)
- refs DESIGN/35 §10.2 (案 C: 2 件ずつ 2 PR)

## 変更点 / Changes

### victim-web 側 (脆弱エンドポイント拡張)

- [services/victim-web/src/routes/jwt-vuln.ts](services/victim-web/src/routes/jwt-vuln.ts): `SEED_USER_PROFILES` (alice/bob/admin) を追加し、alg=none / HS256 両経路で `claims.sub` に対応するプロファイルを `leakedToAttacker` に詰めて返す。教材ヘッダ `X-Token-Alg` / `X-Forged-Sub` / `X-Forged-Role` を付与
- [services/victim-web/src/routes/oauth-vuln.ts](services/victim-web/src/routes/oauth-vuln.ts): state なしで code を発行する際、後段の token exchange で奪取される予定の `VICTIM_PROFILE_AT_RISK` (`futureAccessToken` / email / scopes) を `leakedToAttacker` に詰める。教材ヘッダ `X-Authorization-Code` / `X-Csrf-Risk` / `X-State-Validated` を付与

### scenario 側 (story 7 シーン執筆)

- [src/components/auth/attacks/scenarios/jwt-scenarios.ts](src/components/auth/attacks/scenarios/jwt-scenarios.ts): `jwt-alg-none` に 7 シーン story (setup → recon → forge → send → server-fails → leak → defense) + `storyDefaultDurationMs: 4000` 追加
- [src/components/auth/attacks/scenarios/oauth-scenarios.ts](src/components/auth/attacks/scenarios/oauth-scenarios.ts): `oauth-state-csrf` に 7 シーン story (setup → recon → victim-act → exploit → server-fails → leak → defense) 追加
- 両者ともシーン 5 (server-fails) は `data-leak` visual で X-Forged-Role / X-Csrf-Risk ヘッダを参照、シーン 6 (leak) はレスポンスボディの `leakedToAttacker` を `severity: critical` で赤枠強調

### テスト

- [services/victim-web/\_\_tests\_\_/jwt-vuln.test.ts](services/victim-web/__tests__/jwt-vuln.test.ts) (**新規**, 6 tests): alg=none / HS256 経路で `leakedToAttacker` + 教材ヘッダが返ること、未知 sub では null になること、token 欠如/Invalid JSON で 400 を検証
- [services/victim-web/\_\_tests\_\_/oauth-vuln.test.ts](services/victim-web/__tests__/oauth-vuln.test.ts) (+2 tests = 6): `leakedToAttacker` shape + 教材ヘッダ検証
- [server/\_\_tests\_\_/scenarios/oauth-state-csrf.test.ts](server/__tests__/scenarios/oauth-state-csrf.test.ts) (+1 test = 5): orchestrator → victim 経路で `leakedToAttacker` + 教材ヘッダがそのまま `rawExchange` に保存されることを e2e 検証

### ドキュメント

- [CLAUDE.md](CLAUDE.md) DESIGN ⇄ 実装対応表に PR-A 行 2 件追加

## スクリーンショット (UI 変更時) / Screenshots

`oauth-state-csrf` シーン 6 (leak):

- 攻撃者アバター + 吹き出し: 「code を持ったから、次の /oauth/token でアクセストークンと alice のプロファイルが手に入る。」
- `data-leak` visual に full response body を赤枠強調表示 (`leakedToAttacker.username = "seed_alice"`, `email = "alice@victim.local"`, `futureAccessToken = "VICTIM_AT_REDACTED_alice_seed_8a9c"`, `authorizationCode = "vuln-code-..."`)

`jwt-alg-none` シーン 5 (server-fails):

- victim-srv アバター + 吹き出し: 「alg=none か。algorithms は指定されていない。じゃあ署名チェックはスキップでいいな。」
- `data-leak` visual: 「偽造 role を受理 (X-Forged-Role): admin」を `severity: high` で赤枠強調

## テスト方法 / How to test

- [x] `npm run dev:no-docker` でフロント:3000 + バックエンド:3001 + victim-web:4001 を起動
- [x] `curl http://localhost:3001/api/health` が OK を返す
- [x] **JWT 攻撃者モード** で `alg=none 攻撃` を選択し送信 (LIVE) → 7 シーン storyboard が表示され、シーン 6 で alice の email / 残高 / API キーが leakedToAttacker として漏えい表示される
- [x] **OAuth 攻撃者モード** で `state 欠落 CSRF` を選択し送信 (LIVE) → 7 シーン storyboard が表示され、シーン 6 で futureAccessToken + alice の profile が leakedToAttacker として漏えい表示される
- [x] `npm test -- --run` 550/550 pass
- [x] `npx tsc --noEmit` clean

## DESIGN ⇄ 実装 整合性 / Design ↔ Implementation alignment

- [x] DESIGN/35 §8.3 (7 シーン版テンプレ) / §8.4 (文量規約) / §10.2 案 C を確認
- [x] 既存 victim-web 単体テストパターン (oauth-vuln.test.ts / totp-vuln.test.ts) と整合
- [x] CLAUDE.md DESIGN ⇄ 実装対応表に PR-A 行を追加

## live モード安全装置の確認 / Live-mode safety controls

- [x] 新規/変更 victim エンドポイントは存在しない (既存 jwt-vuln / oauth-vuln の応答シェイプ拡張のみ)
- [x] 既存 VICTIM_ALLOWLIST / production guard / Host 強制上書きは無変更
- [x] `leakedToAttacker` の値はすべて `_DEMO_` / `@victim.local` / `REDACTED` マーカー入りの教材スタブで、本物の secret は含まない (DESIGN/04 §2.3 禁止表現一覧チェック済み)
- [x] LIVE バッジ密度は据え置き (新規バッジ追加なし、`feedback_live_badges` メモリと整合)

🤖 Generated with [Claude Code](https://claude.com/claude-code)